### PR TITLE
[AN][feat]: 메인 화면 바텀 네비게이션 이동 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.fragment.ktx)
 
     // 네트워크 통신 관련 라이브러리
     implementation(libs.okhttp)

--- a/android/app/src/main/java/com/mulkkam/ui/binding/BindingActivity.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/binding/BindingActivity.kt
@@ -14,6 +14,8 @@ open class BindingActivity<BINDING : ViewBinding>(
     private var _binding: BINDING? = null
     val binding get() = _binding!!
 
+    open val needBottomPadding: Boolean = true
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         _binding = bindingInflater(layoutInflater)
@@ -25,7 +27,8 @@ open class BindingActivity<BINDING : ViewBinding>(
     private fun initViewPadding() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            val bottomPadding = if (needBottomPadding) systemBars.bottom else 0
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, bottomPadding)
             insets
         }
     }

--- a/android/app/src/main/java/com/mulkkam/ui/binding/BindingActivity.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/binding/BindingActivity.kt
@@ -17,6 +17,7 @@ open class BindingActivity<BINDING : ViewBinding>(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         _binding = bindingInflater(layoutInflater)
+        setContentView(binding.root)
         enableEdgeToEdge()
         initViewPadding()
     }

--- a/android/app/src/main/java/com/mulkkam/ui/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/home/HomeFragment.kt
@@ -1,0 +1,14 @@
+package com.mulkkam.ui.home
+
+import com.mulkkam.databinding.FragmentHomeBinding
+import com.mulkkam.ui.binding.BindingFragment
+import com.mulkkam.ui.main.MainActivity
+
+class HomeFragment :
+    BindingFragment<FragmentHomeBinding>(
+        FragmentHomeBinding::inflate,
+    ),
+    MainActivity.Refreshable {
+    override fun onSelected() {
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/ui/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/home/HomeFragment.kt
@@ -10,5 +10,6 @@ class HomeFragment :
     ),
     MainActivity.Refreshable {
     override fun onSelected() {
+        // TODO: 화면 전환 시 필요한 작업을 구현합니다.
     }
 }

--- a/android/app/src/main/java/com/mulkkam/ui/main/MainActivity.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/main/MainActivity.kt
@@ -1,9 +1,77 @@
 package com.mulkkam.ui.main
 
+import android.os.Bundle
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
+import androidx.fragment.app.commit
+import com.mulkkam.R
 import com.mulkkam.databinding.ActivityMainBinding
 import com.mulkkam.ui.binding.BindingActivity
+import com.mulkkam.ui.model.MainTab
 
-class MainActivity :
-    BindingActivity<ActivityMainBinding>(
-        ActivityMainBinding::inflate,
-    )
+class MainActivity : BindingActivity<ActivityMainBinding>(ActivityMainBinding::inflate) {
+    override val needBottomPadding: Boolean
+        get() = binding.bnvMain.isVisible.not()
+
+    private val tabs: MutableMap<MainTab, Fragment> = mutableMapOf()
+    private var currentTab: MainTab? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        initBottomNavListener()
+        if (savedInstanceState == null) {
+            switchFragment(MainTab.HOME)
+        }
+    }
+
+    private fun initBottomNavListener() {
+        binding.bnvMain.setOnItemSelectedListener { item ->
+            MainTab.from(item.itemId)?.let { menu ->
+                switchFragment(menu)
+                true
+            } ?: false
+        }
+    }
+
+    private fun switchFragment(target: MainTab) {
+        if (currentTab == target) return
+
+        val fragment = prepareFragment(target)
+
+        supportFragmentManager.commit {
+            setReorderingAllowed(true)
+            hideOtherFragments(except = target)
+            show(fragment)
+        }
+
+        if (fragment is Refreshable) {
+            fragment.onSelected()
+        }
+
+        currentTab = target
+    }
+
+    private fun prepareFragment(tab: MainTab): Fragment =
+        tabs.getOrPut(tab) {
+            tab.create().also { fragment ->
+                supportFragmentManager.commit {
+                    setReorderingAllowed(true)
+                    add(R.id.fcv_main, fragment, tab.name)
+                }
+            }
+        }
+
+    private fun FragmentTransaction.hideOtherFragments(except: MainTab) {
+        tabs
+            .filterKeys { it != except }
+            .forEach { (_, fragment) ->
+                hide(fragment)
+            }
+    }
+
+    interface Refreshable {
+        fun onSelected()
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/ui/main/MainActivity.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/main/MainActivity.kt
@@ -1,21 +1,9 @@
 package com.mulkkam.ui.main
 
-import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import com.mulkkam.R
+import com.mulkkam.databinding.ActivityMainBinding
+import com.mulkkam.ui.binding.BindingActivity
 
-class MainActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContentView(R.layout.activity_main)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
-        }
-    }
-}
+class MainActivity :
+    BindingActivity<ActivityMainBinding>(
+        ActivityMainBinding::inflate,
+    )

--- a/android/app/src/main/java/com/mulkkam/ui/model/MainTab.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/model/MainTab.kt
@@ -1,0 +1,24 @@
+package com.mulkkam.ui.model
+
+import androidx.annotation.IdRes
+import androidx.fragment.app.Fragment
+import com.mulkkam.R
+import com.mulkkam.ui.home.HomeFragment
+import com.mulkkam.ui.record.RecordFragment
+import com.mulkkam.ui.setting.SettingFragment
+
+enum class MainTab(
+    @IdRes val menuId: Int,
+    val create: () -> Fragment,
+) {
+    HOME(R.id.item_home, { HomeFragment() }),
+    RECORD(R.id.item_record, { RecordFragment() }),
+    SETTING(R.id.item_setting, { SettingFragment() }),
+    ;
+
+    companion object {
+        fun from(
+            @IdRes id: Int,
+        ): MainTab? = entries.find { it.menuId == id }
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/ui/record/RecordFragment.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/record/RecordFragment.kt
@@ -10,5 +10,6 @@ class RecordFragment :
     ),
     MainActivity.Refreshable {
     override fun onSelected() {
+        // TODO: 화면 전환 시 필요한 작업을 구현합니다.
     }
 }

--- a/android/app/src/main/java/com/mulkkam/ui/record/RecordFragment.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/record/RecordFragment.kt
@@ -1,0 +1,14 @@
+package com.mulkkam.ui.record
+
+import com.mulkkam.databinding.FragmentRecordBinding
+import com.mulkkam.ui.binding.BindingFragment
+import com.mulkkam.ui.main.MainActivity
+
+class RecordFragment :
+    BindingFragment<FragmentRecordBinding>(
+        FragmentRecordBinding::inflate,
+    ),
+    MainActivity.Refreshable {
+    override fun onSelected() {
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/ui/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/setting/SettingFragment.kt
@@ -1,0 +1,14 @@
+package com.mulkkam.ui.setting
+
+import com.mulkkam.databinding.FragmentSettingBinding
+import com.mulkkam.ui.binding.BindingFragment
+import com.mulkkam.ui.main.MainActivity
+
+class SettingFragment :
+    BindingFragment<FragmentSettingBinding>(
+        FragmentSettingBinding::inflate,
+    ),
+    MainActivity.Refreshable {
+    override fun onSelected() {
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/ui/setting/SettingFragment.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/setting/SettingFragment.kt
@@ -10,5 +10,6 @@ class SettingFragment :
     ),
     MainActivity.Refreshable {
     override fun onSelected() {
+        // TODO: 화면 전환 시 필요한 작업을 구현합니다.
     }
 }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -2,18 +2,25 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.main.MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fcv_main"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/bnv_main"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bnv_main"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/menu_bottom_nav" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Home Fragment"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/fragment_record.xml
+++ b/android/app/src/main/res/layout/fragment_record.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Record Fragment"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/fragment_setting.xml
+++ b/android/app/src/main/res/layout/fragment_setting.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Setting Fragment"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/menu/menu_bottom_nav.xml
+++ b/android/app/src/main/res/menu/menu_bottom_nav.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/item_home"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="@string/main_home" />
+    <item
+        android:id="@+id/item_record"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="@string/main_record" />
+    <item
+        android:id="@+id/item_setting"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="@string/main_setting" />
+</menu>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">MulKkam</string>
+
+    <string name="main_home">홈</string>
+    <string name="main_record">기록</string>
+    <string name="main_setting">설정</string>
 </resources>

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ mannodermaus-junit5 = "1.7.0"
 android-junit5 = "1.12.0.0"
 mpandroidchart = "v3.1.0"
 ktlint = "13.0.0"
+fragment-ktx = "1.8.8"
 
 [libraries]
 # AndroidX 및 UI
@@ -33,6 +34,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment-ktx" }
 
 # 네트워크 및 직렬화
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #34

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 메인 화면 바텀 네비게이션 이동 구현

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. BindingActivity에서 기본적으로 주어지는 bottom padding을 넣어야 하는지 여부를 결정할 수 있음
2. MainActivity에서 각 메인 탭을 hide 와 show를 활용해 전환하도록 구현
3. MainTab enum class를 통해 모든 메인 탭을 관리하도록 구현
4. Refreshable의 onSelected 함수를 통해 탭이 바뀌었을 경우 각 Fragment 내부에서 감지할 수 있도록 구현

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/6cb417de-9553-4e21-a590-e0c8270ad059