### PR TITLE
[BE][feat]: 음수량 기록 기능 구현

### DIFF
--- a/backend/src/main/java/backend/mulkkam/intake/controller/IntakeHistoryController.java
+++ b/backend/src/main/java/backend/mulkkam/intake/controller/IntakeHistoryController.java
@@ -1,15 +1,22 @@
 package backend.mulkkam.intake.controller;
 
+import backend.mulkkam.intake.dto.IntakeHistoryCreateRequest;
+import backend.mulkkam.intake.service.IntakeHistoryService;
 import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/intake/history")
 public class IntakeHistoryController {
+
+    private final IntakeHistoryService intakeHistoryService;
 
     @GetMapping
     public void get(
@@ -20,7 +27,7 @@ public class IntakeHistoryController {
     }
 
     @PostMapping
-    public void create() {
-
+    public void create(@RequestBody IntakeHistoryCreateRequest intakeHistoryCreateRequest) {
+        intakeHistoryService.create(intakeHistoryCreateRequest, 1L);
     }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/domain/IntakeHistory.java
+++ b/backend/src/main/java/backend/mulkkam/intake/domain/IntakeHistory.java
@@ -40,7 +40,12 @@ public class IntakeHistory {
     @AttributeOverride(name = "value", column = @Column(name = "targetAmount", nullable = false))
     private Amount targetAmount;
 
-    public IntakeHistory(Member member, LocalDateTime dateTime, Amount intakeAmount, Amount targetAmount) {
+    public IntakeHistory(
+            Member member,
+            LocalDateTime dateTime,
+            Amount intakeAmount,
+            Amount targetAmount
+    ) {
         this.member = member;
         this.dateTime = dateTime;
         this.intakeAmount = intakeAmount;

--- a/backend/src/main/java/backend/mulkkam/intake/domain/IntakeHistory.java
+++ b/backend/src/main/java/backend/mulkkam/intake/domain/IntakeHistory.java
@@ -12,10 +12,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -40,4 +39,11 @@ public class IntakeHistory {
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "targetAmount", nullable = false))
     private Amount targetAmount;
+
+    public IntakeHistory(Member member, LocalDateTime dateTime, Amount intakeAmount, Amount targetAmount) {
+        this.member = member;
+        this.dateTime = dateTime;
+        this.intakeAmount = intakeAmount;
+        this.targetAmount = targetAmount;
+    }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/dto/IntakeHistoryCreateRequest.java
+++ b/backend/src/main/java/backend/mulkkam/intake/dto/IntakeHistoryCreateRequest.java
@@ -1,0 +1,20 @@
+package backend.mulkkam.intake.dto;
+
+import backend.mulkkam.intake.domain.IntakeHistory;
+import backend.mulkkam.intake.domain.vo.Amount;
+import backend.mulkkam.member.domain.Member;
+import java.time.LocalDateTime;
+
+public record IntakeHistoryCreateRequest(
+        LocalDateTime dateTime,
+        int intakeAmount
+) {
+    public IntakeHistory toIntakeHistory(Member member) {
+        return new IntakeHistory(
+                member,
+                dateTime,
+                new Amount(intakeAmount),
+                member.getTargetAmount()
+        );
+    }
+}

--- a/backend/src/main/java/backend/mulkkam/intake/repository/IntakeHistoryRepository.java
+++ b/backend/src/main/java/backend/mulkkam/intake/repository/IntakeHistoryRepository.java
@@ -1,7 +1,10 @@
 package backend.mulkkam.intake.repository;
 
 import backend.mulkkam.intake.domain.IntakeHistory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IntakeHistoryRepository extends JpaRepository<IntakeHistory, Long> {
+    // TODO: 단위 테스트 추가하기
+    List<IntakeHistory> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -6,6 +6,7 @@ import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +30,6 @@ public class IntakeHistoryService {
 
     private Member getMember(Long id) {
         return memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NoSuchElementException("해당 회원을 찾을 수 없습니다."));
     }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -21,13 +21,13 @@ public class IntakeHistoryService {
             IntakeHistoryCreateRequest intakeHistoryCreateRequest,
             Long memberId
     ) {
-        Member member = findMember(memberId);
+        Member member = getMember(memberId);
 
         IntakeHistory intakeHistory = intakeHistoryCreateRequest.toIntakeHistory(member);
         intakeHistoryRepository.save(intakeHistory);
     }
 
-    private Member findMember(Long id) {
+    private Member getMember(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
     }

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -1,13 +1,31 @@
 package backend.mulkkam.intake.service;
 
+import backend.mulkkam.intake.domain.IntakeHistory;
+import backend.mulkkam.intake.dto.IntakeHistoryCreateRequest;
 import backend.mulkkam.intake.repository.IntakeHistoryRepository;
+import backend.mulkkam.member.domain.Member;
+import backend.mulkkam.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequiredArgsConstructor
 @Service
 public class IntakeHistoryService {
 
     private final IntakeHistoryRepository intakeHistoryRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void create(IntakeHistoryCreateRequest intakeHistoryCreateRequest, Long memberId) {
+        Member member = findMember(memberId);
+
+        IntakeHistory intakeHistory = intakeHistoryCreateRequest.toIntakeHistory(member);
+        intakeHistoryRepository.save(intakeHistory);
+    }
+
+    private Member findMember(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
+    }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -17,7 +17,10 @@ public class IntakeHistoryService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void create(IntakeHistoryCreateRequest intakeHistoryCreateRequest, Long memberId) {
+    public void create(
+            IntakeHistoryCreateRequest intakeHistoryCreateRequest,
+            Long memberId
+    ) {
         Member member = findMember(memberId);
 
         IntakeHistory intakeHistory = intakeHistoryCreateRequest.toIntakeHistory(member);

--- a/backend/src/main/java/backend/mulkkam/member/domain/Member.java
+++ b/backend/src/main/java/backend/mulkkam/member/domain/Member.java
@@ -40,7 +40,12 @@ public class Member {
     @AttributeOverride(name = "value", column = @Column(name = "targetAmount", nullable = false))
     private Amount targetAmount;
 
-    public Member(MemberNickname memberNickname, Gender gender, Integer weight, Amount targetAmount) {
+    public Member(
+            MemberNickname memberNickname,
+            Gender gender,
+            Integer weight,
+            Amount targetAmount
+    ) {
         this.memberNickname = memberNickname;
         this.gender = gender;
         this.weight = weight;

--- a/backend/src/main/java/backend/mulkkam/member/domain/Member.java
+++ b/backend/src/main/java/backend/mulkkam/member/domain/Member.java
@@ -39,4 +39,11 @@ public class Member {
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "targetAmount", nullable = false))
     private Amount targetAmount;
+
+    public Member(MemberNickname memberNickname, Gender gender, Integer weight, Amount targetAmount) {
+        this.memberNickname = memberNickname;
+        this.gender = gender;
+        this.weight = weight;
+        this.targetAmount = targetAmount;
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/test_db
+    username: root
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -7,23 +7,20 @@ import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.repository.MemberRepository;
 import backend.mulkkam.support.MemberFixture;
+import backend.mulkkam.support.ServiceIntegrationTest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
-class IntakeHistoryServiceIntegrationTest {
+class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
 
     @Autowired
     private IntakeHistoryService intakeHistoryService;
@@ -33,12 +30,6 @@ class IntakeHistoryServiceIntegrationTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @BeforeEach
-    void setUp() {
-        intakeHistoryRepository.deleteAllInBatch();
-        memberRepository.deleteAllInBatch();
-    }
 
     @DisplayName("물의 섭취량을 저장할 때에")
     @Nested

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -45,7 +45,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
         void success_amountMoreThen0() {
             // given
             Member member = new MemberFixture().build();
-            memberRepository.save(member);
+            Member savedMember = memberRepository.save(member);
 
             int intakeAmount = 500;
             IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
@@ -57,7 +57,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             intakeHistoryService.create(intakeHistoryCreateRequest, member.getId());
 
             // then
-            List<IntakeHistory> intakeHistories = intakeHistoryRepository.findAll();
+            List<IntakeHistory> intakeHistories = intakeHistoryRepository.findAllByMemberId(savedMember.getId());
             assertSoftly(softly -> {
                 softly.assertThat(intakeHistories).hasSize(1);
                 softly.assertThat(intakeHistories.getFirst().getIntakeAmount()).isEqualTo(new Amount(intakeAmount));
@@ -87,10 +87,6 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
         @Test
         void error_memberIsNotExisted() {
             // given
-            LocalDateTime dateTime = LocalDateTime.of(
-                    LocalDate.of(2025, 3, 19),
-                    LocalTime.of(15, 30, 30)
-            );
             int intakeAmount = 500;
             IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
                     DATE_TIME,

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -35,6 +35,11 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
     @Nested
     class Create {
 
+        public static final LocalDateTime DATE_TIME = LocalDateTime.of(
+                LocalDate.of(2025, 3, 19),
+                LocalTime.of(15, 30, 30)
+        );
+
         @DisplayName("용량이 0보다 큰 경우 정상적으로 저장된다")
         @Test
         void success_amountMoreThen0() {
@@ -42,13 +47,9 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             Member member = new MemberFixture().build();
             memberRepository.save(member);
 
-            LocalDateTime dateTime = LocalDateTime.of(
-                    LocalDate.of(2025, 3, 19),
-                    LocalTime.of(15, 30, 30)
-            );
             int intakeAmount = 500;
             IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
-                    dateTime,
+                    DATE_TIME,
                     intakeAmount
             );
 
@@ -60,7 +61,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             assertSoftly(softly -> {
                 softly.assertThat(intakeHistories).hasSize(1);
                 softly.assertThat(intakeHistories.getFirst().getIntakeAmount()).isEqualTo(new Amount(intakeAmount));
-                softly.assertThat(intakeHistories.getFirst().getDateTime()).isEqualTo(dateTime);
+                softly.assertThat(intakeHistories.getFirst().getDateTime()).isEqualTo(DATE_TIME);
             });
         }
 
@@ -71,13 +72,9 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             Member member = new MemberFixture().build();
             memberRepository.save(member);
 
-            LocalDateTime dateTime = LocalDateTime.of(
-                    LocalDate.of(2025, 3, 19),
-                    LocalTime.of(15, 30, 30)
-            );
             int intakeAmount = -1;
             IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
-                    dateTime,
+                    DATE_TIME,
                     intakeAmount
             );
 
@@ -96,7 +93,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             );
             int intakeAmount = 500;
             IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
-                    dateTime,
+                    DATE_TIME,
                     intakeAmount
             );
 

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
 
             // when & then
             assertThatThrownBy(() -> intakeHistoryService.create(intakeHistoryCreateRequest, Long.MAX_VALUE))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(NoSuchElementException.class);
         }
     }
 }

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
-class IntakeHistoryServiceTest {
+class IntakeHistoryServiceIntegrationTest {
 
     @Autowired
     private IntakeHistoryService intakeHistoryService;

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceTest.java
@@ -1,0 +1,117 @@
+package backend.mulkkam.intake.service;
+
+import backend.mulkkam.intake.domain.IntakeHistory;
+import backend.mulkkam.intake.domain.vo.Amount;
+import backend.mulkkam.intake.dto.IntakeHistoryCreateRequest;
+import backend.mulkkam.intake.repository.IntakeHistoryRepository;
+import backend.mulkkam.member.domain.Member;
+import backend.mulkkam.member.repository.MemberRepository;
+import backend.mulkkam.support.MemberFixture;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class IntakeHistoryServiceTest {
+
+    @Autowired
+    private IntakeHistoryService intakeHistoryService;
+
+    @Autowired
+    private IntakeHistoryRepository intakeHistoryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        intakeHistoryRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("물의 섭취량을 저장할 때에")
+    @Nested
+    class Create {
+
+        @DisplayName("용량이 0보다 큰 경우 정상적으로 저장된다")
+        @Test
+        void success_amountMoreThen0() {
+            // given
+            Member member = new MemberFixture().build();
+            memberRepository.save(member);
+
+            LocalDateTime dateTime = LocalDateTime.of(
+                    LocalDate.of(2025, 3, 19),
+                    LocalTime.of(15, 30, 30)
+            );
+            int intakeAmount = 500;
+            IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
+                    dateTime,
+                    intakeAmount
+            );
+
+            // when
+            intakeHistoryService.create(intakeHistoryCreateRequest, member.getId());
+
+            // then
+            List<IntakeHistory> intakeHistories = intakeHistoryRepository.findAll();
+            assertSoftly(softly -> {
+                softly.assertThat(intakeHistories).hasSize(1);
+                softly.assertThat(intakeHistories.getFirst().getIntakeAmount()).isEqualTo(new Amount(intakeAmount));
+                softly.assertThat(intakeHistories.getFirst().getDateTime()).isEqualTo(dateTime);
+            });
+        }
+
+        @DisplayName("용량이 음수인 경우 예외가 발생한다")
+        @Test
+        void error_amountIsLessThen0() {
+            // given
+            Member member = new MemberFixture().build();
+            memberRepository.save(member);
+
+            LocalDateTime dateTime = LocalDateTime.of(
+                    LocalDate.of(2025, 3, 19),
+                    LocalTime.of(15, 30, 30)
+            );
+            int intakeAmount = -1;
+            IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
+                    dateTime,
+                    intakeAmount
+            );
+
+            // when & then
+            assertThatThrownBy(() -> intakeHistoryService.create(intakeHistoryCreateRequest, member.getId()))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @DisplayName("존재하지 않는 회원에 대한 요청인 경우 예외가 발생한다")
+        @Test
+        void error_memberIsNotExisted() {
+            // given
+            LocalDateTime dateTime = LocalDateTime.of(
+                    LocalDate.of(2025, 3, 19),
+                    LocalTime.of(15, 30, 30)
+            );
+            int intakeAmount = 500;
+            IntakeHistoryCreateRequest intakeHistoryCreateRequest = new IntakeHistoryCreateRequest(
+                    dateTime,
+                    intakeAmount
+            );
+
+            // when & then
+            assertThatThrownBy(() -> intakeHistoryService.create(intakeHistoryCreateRequest, Long.MAX_VALUE))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
@@ -1,0 +1,123 @@
+package backend.mulkkam.intake.service;
+
+import backend.mulkkam.intake.domain.IntakeHistory;
+import backend.mulkkam.intake.dto.IntakeHistoryCreateRequest;
+import backend.mulkkam.intake.repository.IntakeHistoryRepository;
+import backend.mulkkam.member.domain.Member;
+import backend.mulkkam.member.repository.MemberRepository;
+import backend.mulkkam.support.MemberFixture;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class IntakeHistoryServiceUnitTest {
+
+    @InjectMocks
+    private IntakeHistoryService intakeHistoryService;
+
+    @Mock
+    private IntakeHistoryRepository intakeHistoryRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @DisplayName("물의 섭취량을 저장할 때에")
+    @Nested
+    class Create {
+
+        @DisplayName("용량이 0보다 큰 경우 정상적으로 저장된다")
+        @Test
+        void success_amountMoreThen0() {
+            // given
+            Long memberId = 1L;
+            Member member = new MemberFixture().build();
+            given(memberRepository.findById(memberId))
+                    .willReturn(Optional.of(member));
+
+            LocalDateTime dateTime = LocalDateTime.of(
+                    LocalDate.of(2025, 3, 19),
+                    LocalTime.of(15, 30, 30)
+            );
+            int intakeAmount = 500;
+            IntakeHistoryCreateRequest request = new IntakeHistoryCreateRequest(
+                    dateTime,
+                    intakeAmount
+            );
+
+            // when
+            intakeHistoryService.create(request, memberId);
+
+            // then
+            verify(memberRepository).findById(memberId);
+            verify(intakeHistoryRepository).save(any(IntakeHistory.class));
+        }
+
+        @DisplayName("용량이 음수인 경우 예외가 발생한다")
+        @Test
+        void error_amountIsLessThen0() {
+            // given
+            Long memberId = 1L;
+            Member member = new MemberFixture().build();
+            given(memberRepository.findById(memberId))
+                    .willReturn(Optional.of(member));
+
+            LocalDateTime dateTime = LocalDateTime.of(
+                    LocalDate.of(2025, 3, 19),
+                    LocalTime.of(15, 30, 30)
+            );
+            int intakeAmount = -1;
+            IntakeHistoryCreateRequest request = new IntakeHistoryCreateRequest(
+                    dateTime,
+                    intakeAmount
+            );
+
+            // when & then
+            assertThatThrownBy(() -> intakeHistoryService.create(request, memberId))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            // 저장이 호출되지 않았는지 검증
+            verify(intakeHistoryRepository, never()).save(any(IntakeHistory.class));
+        }
+
+        @DisplayName("존재하지 않는 회원에 대한 요청인 경우 예외가 발생한다")
+        @Test
+        void error_memberIsNotExisted() {
+            // given
+            Long memberId = 999L;
+            given(memberRepository.findById(memberId))
+                    .willReturn(Optional.empty());
+
+            LocalDateTime dateTime = LocalDateTime.of(
+                    LocalDate.of(2025, 3, 19),
+                    LocalTime.of(15, 30, 30)
+            );
+            int intakeAmount = 500;
+            IntakeHistoryCreateRequest request = new IntakeHistoryCreateRequest(
+                    dateTime,
+                    intakeAmount
+            );
+
+            // when & then
+            assertThatThrownBy(() -> intakeHistoryService.create(request, memberId))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("해당 회원을 찾을 수 없습니다.");
+
+            verify(intakeHistoryRepository, never()).save(any(IntakeHistory.class));
+        }
+    }
+}

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
@@ -9,6 +9,7 @@ import backend.mulkkam.support.MemberFixture;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -106,7 +107,7 @@ class IntakeHistoryServiceUnitTest {
 
             // when & then
             assertThatThrownBy(() -> intakeHistoryService.create(request, memberId))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(NoSuchElementException.class)
                     .hasMessage("해당 회원을 찾을 수 없습니다.");
 
             verify(intakeHistoryRepository, never()).save(any(IntakeHistory.class));

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
@@ -87,7 +87,6 @@ class IntakeHistoryServiceUnitTest {
             assertThatThrownBy(() -> intakeHistoryService.create(request, memberId))
                     .isInstanceOf(IllegalArgumentException.class);
 
-            // 저장이 호출되지 않았는지 검증
             verify(intakeHistoryRepository, never()).save(any(IntakeHistory.class));
         }
 

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
@@ -40,6 +40,11 @@ class IntakeHistoryServiceUnitTest {
     @Nested
     class Create {
 
+        public static final LocalDateTime DATE_TIME = LocalDateTime.of(
+                LocalDate.of(2025, 3, 19),
+                LocalTime.of(15, 30, 30)
+        );
+
         @DisplayName("용량이 0보다 큰 경우 정상적으로 저장된다")
         @Test
         void success_amountMoreThen0() {
@@ -49,13 +54,9 @@ class IntakeHistoryServiceUnitTest {
             given(memberRepository.findById(memberId))
                     .willReturn(Optional.of(member));
 
-            LocalDateTime dateTime = LocalDateTime.of(
-                    LocalDate.of(2025, 3, 19),
-                    LocalTime.of(15, 30, 30)
-            );
             int intakeAmount = 500;
             IntakeHistoryCreateRequest request = new IntakeHistoryCreateRequest(
-                    dateTime,
+                    DATE_TIME,
                     intakeAmount
             );
 
@@ -76,13 +77,9 @@ class IntakeHistoryServiceUnitTest {
             given(memberRepository.findById(memberId))
                     .willReturn(Optional.of(member));
 
-            LocalDateTime dateTime = LocalDateTime.of(
-                    LocalDate.of(2025, 3, 19),
-                    LocalTime.of(15, 30, 30)
-            );
             int intakeAmount = -1;
             IntakeHistoryCreateRequest request = new IntakeHistoryCreateRequest(
-                    dateTime,
+                    DATE_TIME,
                     intakeAmount
             );
 
@@ -102,13 +99,9 @@ class IntakeHistoryServiceUnitTest {
             given(memberRepository.findById(memberId))
                     .willReturn(Optional.empty());
 
-            LocalDateTime dateTime = LocalDateTime.of(
-                    LocalDate.of(2025, 3, 19),
-                    LocalTime.of(15, 30, 30)
-            );
             int intakeAmount = 500;
             IntakeHistoryCreateRequest request = new IntakeHistoryCreateRequest(
-                    dateTime,
+                    DATE_TIME,
                     intakeAmount
             );
 

--- a/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
+++ b/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
@@ -1,9 +1,9 @@
 package backend.mulkkam.support;
 
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class DatabaseCleaner {

--- a/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
+++ b/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
@@ -1,6 +1,8 @@
 package backend.mulkkam.support;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.Type;
 import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,101 +12,36 @@ public class DatabaseCleaner {
 
     private final EntityManager entityManager;
 
-    public DatabaseCleaner(EntityManager entityManager) {
+    public DatabaseCleaner(final EntityManager entityManager) {
         this.entityManager = entityManager;
     }
 
     @Transactional
-    public void truncateAllTables() {
-        String databaseName = getDatabaseName();
+    public void clean() {
+        List<String> tableNames = entityManager.getMetamodel()
+                .getEntities()
+                .stream()
+                .map(Type::getJavaType)
+                .map(javaType -> {
+                    Table table = javaType.getAnnotation(Table.class);
+                    return (table != null && !table.name().isBlank())
+                            ? table.name()
+                            : toSnakeCase(javaType.getSimpleName());
+                })
+                .toList();
 
-        if (isH2Database(databaseName)) {
-            cleanH2Database();
-        } else if (isMySQLDatabase(databaseName)) {
-            cleanMySQLDatabase();
-        } else {
-            throw new UnsupportedOperationException("지원하지 않는 데이터베이스입니다: " + databaseName);
-        }
-    }
+        entityManager.flush();
+        entityManager.createNativeQuery("SET foreign_key_checks = 0").executeUpdate();
 
-    private void cleanH2Database() {
-        // H2에서 외래 키 제약조건 비활성화
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
-
-        // H2용 테이블 목록 조회
-        List<String> tableNames = entityManager.createNativeQuery(
-                        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
-                                "WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_TYPE = 'BASE TABLE'")
-                .getResultList();
-
-        // 테이블 정리
-        for (String table : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
         }
 
-        // 외래 키 제약조건 다시 활성화
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
+
     }
 
-    private void cleanMySQLDatabase() {
-        // MySQL에서 외래 키 체크 비활성화
-        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
-
-        // 현재 스키마 이름 가져오기
-        String schema = (String) entityManager
-                .createNativeQuery("SELECT DATABASE()")
-                .getSingleResult();
-
-        // MySQL용 테이블 목록 조회
-        List<String> tableNames = entityManager.createNativeQuery(
-                        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
-                                "WHERE TABLE_SCHEMA = :schema AND TABLE_TYPE = 'BASE TABLE'")
-                .setParameter("schema", schema)
-                .getResultList();
-
-        // 테이블 순회하여 TRUNCATE 및 AUTO_INCREMENT 초기화
-        for (String table : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
-        }
-
-        // 외래 키 체크 다시 활성화
-        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
-    }
-
-    private String getDatabaseName() {
-        try {
-            // H2인지 확인
-            entityManager.createNativeQuery("SELECT H2VERSION()").getSingleResult();
-            return "H2";
-        } catch (Exception e1) {
-            try {
-                // MySQL인지 확인
-                entityManager.createNativeQuery("SELECT VERSION()").getSingleResult();
-                return "MySQL";
-            } catch (Exception e2) {
-                // 다른 방법으로 데이터베이스 확인
-                String url = entityManager.getEntityManagerFactory()
-                        .getProperties()
-                        .get("hibernate.connection.url")
-                        .toString()
-                        .toLowerCase();
-
-                if (url.contains("h2")) {
-                    return "H2";
-                } else if (url.contains("mysql")) {
-                    return "MySQL";
-                } else {
-                    return "UNKNOWN";
-                }
-            }
-        }
-    }
-
-    private boolean isH2Database(String databaseName) {
-        return "H2".equalsIgnoreCase(databaseName);
-    }
-
-    private boolean isMySQLDatabase(String databaseName) {
-        return "MySQL".equalsIgnoreCase(databaseName);
+    private String toSnakeCase(String input) {
+        return input.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
     }
 }

--- a/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
+++ b/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
@@ -12,7 +12,7 @@ public class DatabaseCleaner {
 
     private final EntityManager entityManager;
 
-    public DatabaseCleaner(final EntityManager entityManager) {
+    public DatabaseCleaner(EntityManager entityManager) {
         this.entityManager = entityManager;
     }
 

--- a/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
+++ b/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
@@ -1,0 +1,37 @@
+package backend.mulkkam.support;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner {
+
+    private final EntityManager entityManager;
+
+    public DatabaseCleaner(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Transactional
+    public void truncateAllTables() {
+        // H2에서 외래 키 제약조건 비활성화
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        // H2용 테이블 목록 조회
+        List<String> tableNames = entityManager.createNativeQuery(
+                        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
+                                "WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_TYPE = 'BASE TABLE'")
+                .getResultList();
+
+        // 테이블 순회하여 TRUNCATE 수행
+        for (String table : tableNames) {
+            // H2에서는 TRUNCATE를 사용하는 것이 더 효율적
+            entityManager.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
+        }
+
+        // 외래 키 제약조건 다시 활성화
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
+++ b/backend/src/test/java/backend/mulkkam/support/DatabaseCleaner.java
@@ -16,6 +16,18 @@ public class DatabaseCleaner {
 
     @Transactional
     public void truncateAllTables() {
+        String databaseName = getDatabaseName();
+
+        if (isH2Database(databaseName)) {
+            cleanH2Database();
+        } else if (isMySQLDatabase(databaseName)) {
+            cleanMySQLDatabase();
+        } else {
+            throw new UnsupportedOperationException("지원하지 않는 데이터베이스입니다: " + databaseName);
+        }
+    }
+
+    private void cleanH2Database() {
         // H2에서 외래 키 제약조건 비활성화
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
 
@@ -25,13 +37,74 @@ public class DatabaseCleaner {
                                 "WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_TYPE = 'BASE TABLE'")
                 .getResultList();
 
-        // 테이블 순회하여 TRUNCATE 수행
+        // 테이블 정리
         for (String table : tableNames) {
-            // H2에서는 TRUNCATE를 사용하는 것이 더 효율적
             entityManager.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
         }
 
         // 외래 키 제약조건 다시 활성화
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private void cleanMySQLDatabase() {
+        // MySQL에서 외래 키 체크 비활성화
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+
+        // 현재 스키마 이름 가져오기
+        String schema = (String) entityManager
+                .createNativeQuery("SELECT DATABASE()")
+                .getSingleResult();
+
+        // MySQL용 테이블 목록 조회
+        List<String> tableNames = entityManager.createNativeQuery(
+                        "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
+                                "WHERE TABLE_SCHEMA = :schema AND TABLE_TYPE = 'BASE TABLE'")
+                .setParameter("schema", schema)
+                .getResultList();
+
+        // 테이블 순회하여 TRUNCATE 및 AUTO_INCREMENT 초기화
+        for (String table : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
+        }
+
+        // 외래 키 체크 다시 활성화
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+    }
+
+    private String getDatabaseName() {
+        try {
+            // H2인지 확인
+            entityManager.createNativeQuery("SELECT H2VERSION()").getSingleResult();
+            return "H2";
+        } catch (Exception e1) {
+            try {
+                // MySQL인지 확인
+                entityManager.createNativeQuery("SELECT VERSION()").getSingleResult();
+                return "MySQL";
+            } catch (Exception e2) {
+                // 다른 방법으로 데이터베이스 확인
+                String url = entityManager.getEntityManagerFactory()
+                        .getProperties()
+                        .get("hibernate.connection.url")
+                        .toString()
+                        .toLowerCase();
+
+                if (url.contains("h2")) {
+                    return "H2";
+                } else if (url.contains("mysql")) {
+                    return "MySQL";
+                } else {
+                    return "UNKNOWN";
+                }
+            }
+        }
+    }
+
+    private boolean isH2Database(String databaseName) {
+        return "H2".equalsIgnoreCase(databaseName);
+    }
+
+    private boolean isMySQLDatabase(String databaseName) {
+        return "MySQL".equalsIgnoreCase(databaseName);
     }
 }

--- a/backend/src/test/java/backend/mulkkam/support/IntakeHistoryFixture.java
+++ b/backend/src/test/java/backend/mulkkam/support/IntakeHistoryFixture.java
@@ -1,0 +1,48 @@
+package backend.mulkkam.support;
+
+import backend.mulkkam.intake.domain.IntakeHistory;
+import backend.mulkkam.intake.domain.vo.Amount;
+import backend.mulkkam.member.domain.Member;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class IntakeHistoryFixture {
+
+    private Member member;
+    private LocalDateTime dateTime = LocalDateTime.of(
+            LocalDate.of(2025, 3, 19),
+            LocalTime.of(15, 30, 30)
+    );
+    private Amount intakeAmount = new Amount(500);
+    private Amount targetIntakeAmount = new Amount(1_000);
+
+    public IntakeHistoryFixture member(Member member) {
+        this.member = member;
+        return this;
+    }
+
+    public IntakeHistoryFixture intakeAmount(Amount intakeAmount) {
+        this.intakeAmount = intakeAmount;
+        return this;
+    }
+
+    public IntakeHistoryFixture targetIntakeAmount(Amount targetIntakeAmount) {
+        this.targetIntakeAmount = targetIntakeAmount;
+        return this;
+    }
+
+    public IntakeHistoryFixture dateTime(LocalDateTime dateTime) {
+        this.dateTime = dateTime;
+        return this;
+    }
+
+    public IntakeHistory build() {
+        return new IntakeHistory(
+                this.member,
+                this.dateTime,
+                this.intakeAmount,
+                this.targetIntakeAmount
+        );
+    }
+}

--- a/backend/src/test/java/backend/mulkkam/support/MemberFixture.java
+++ b/backend/src/test/java/backend/mulkkam/support/MemberFixture.java
@@ -1,0 +1,43 @@
+package backend.mulkkam.support;
+
+import backend.mulkkam.intake.domain.vo.Amount;
+import backend.mulkkam.member.domain.Member;
+import backend.mulkkam.member.domain.vo.Gender;
+import backend.mulkkam.member.domain.vo.MemberNickname;
+
+public class MemberFixture {
+
+    private MemberNickname memberNickname = new MemberNickname("히로");
+    private Gender gender = Gender.FEMALE;
+    private Integer weight = 50;
+    private Amount targetAmount = new Amount(1000);
+
+    public MemberFixture memberNickname(MemberNickname memberNickname) {
+        this.memberNickname = memberNickname;
+        return this;
+    }
+
+    public MemberFixture gender(Gender gender) {
+        this.gender = gender;
+        return this;
+    }
+
+    public MemberFixture weight(Integer weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    public MemberFixture targetAmount(Amount targetAmount) {
+        this.targetAmount = targetAmount;
+        return this;
+    }
+
+    public Member build() {
+        return new Member(
+                this.memberNickname,
+                this.gender,
+                this.weight,
+                this.targetAmount
+        );
+    }
+}

--- a/backend/src/test/java/backend/mulkkam/support/ServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/support/ServiceIntegrationTest.java
@@ -13,6 +13,6 @@ public class ServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        databaseCleaner.truncateAllTables();
+        databaseCleaner.clean();
     }
 }

--- a/backend/src/test/java/backend/mulkkam/support/ServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/support/ServiceIntegrationTest.java
@@ -1,0 +1,18 @@
+package backend.mulkkam.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+public class ServiceIntegrationTest {
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.truncateAllTables();
+    }
+}


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #38 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 음수량 기록 기능을 구현했습니다.

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 테스트를 위한 `MemberFixture` 추가
2. 테스트를 위한 `IntakeHistoryFixture` 추가
3. 음수량 기록 기능 추가
4. 음수량 기록 기능에 대한 서비스 레이어 테스트 추가

## 논의사항

1. 용어 관련

음용량 / 음수량 / 물의 섭취량 등 표현이 조금씩 다르게 쓰이고 있어서,
초반에 하나로 명확히 통일해두면 향후 도메인 모델 설계나 문서 작성에 혼선이 줄어들 것 같아요!

👉 제안: “물 섭취량” or “음수량”, "음용량" 중 하나로 통일하면 어떨까요?

2. `Amount` 관련

Amount는 조금 추상적인 이름이라, 실제로 *“무엇의 양?”*이라는 맥락이 잘 드러나지 않더라구요.
도메인 용어가 명확하면 코드를 처음 보는 사람도 맥락을 쉽게 파악할 수 있으니,
이 부분은 더 의도가 잘 드러나는 이름으로 리네이밍을 제안드려요!

✅ 예시:
- WaterAmount – 단순하고 명확하게
- WaterVolume – 약간 더 단위 중심
- WaterIntake – “섭취”라는 의미에 초점
- DrinkQuantity – 좀 더 추상화된 표현

3. `Amount` 의 유효성 검사 관련

현재 로직에서는 0ml 입력 시 예외가 발생하지 않는데요,
실제 사용 시 현재 기획을 토대로 봤을 때에는, 실수하는 경우가 더 일반적일 것 같아요.

따라서 0ml도 유효하지 않은 입력으로 보고 예외 처리하는 방향이 더 안전하지 않을까 생각해봤습니다!

4. Fixture 방식 관련

Fixture 방식을 처음 써봐서, 칼리가 의도한 방식과 일치하는지 확신이 들지 않아요! 칼리가 더블체크 해주면 좋겠어요 ㅎㅎ

5. application.yml 수정

CI 실패 원인을 보니, 기존에는 엔티티 없이 테스트를 돌렸던 반면
지금은 실제 엔티티를 JPA로 사용하면서 DB와 연동되는 테스트 환경이 필요해졌더라구요.

그래서 테스트용 application.yml을 만들어
CI 상에서도 데이터소스를 인식하도록 설정해봤어요.

[관련 커밋](https://github.com/woowacourse-teams/2025-mul-kkam/pull/57/commits/785289c92b1ca826ad12f6f74100b23a47391c88) 이 커밋에서 CI 를 위한 yaml 을 수정해보았습니다. 간단해보여서 혼자 해봤어요!