### PR TITLE
[BE][fix]: 달성률 소수점까지 도출되도록 수정

### DIFF
--- a/backend/src/main/java/backend/mulkkam/intake/dto/IntakeHistorySummaryResponse.java
+++ b/backend/src/main/java/backend/mulkkam/intake/dto/IntakeHistorySummaryResponse.java
@@ -1,5 +1,6 @@
 package backend.mulkkam.intake.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -7,6 +8,7 @@ public record IntakeHistorySummaryResponse(
         LocalDate date,
         int targetAmount,
         int totalIntakeAmount,
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER, pattern = "0.0")
         double achievementRate,
         List<IntakeHistoryResponse> intakeHistories
 ) {


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #104 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 달성률이 소수점까지 출력되도록 수정


<img width="331" height="424" alt="스크린샷 2025-07-24 오후 8 07 33" src="https://github.com/user-attachments/assets/d40cf712-9d78-4ad8-bbbc-12ec62b4aa77" />
