### PR TITLE
[AN][feat]: 컵 수정 화면에서 API 정보를 받아오도록 수정

### DIFF
--- a/android/app/src/main/java/com/mulkkam/data/remote/model/response/CupResponse.kt
+++ b/android/app/src/main/java/com/mulkkam/data/remote/model/response/CupResponse.kt
@@ -19,7 +19,7 @@ data class CupResponse(
 fun CupResponse.toDomain() =
     Cup(
         id = id,
-        cupNickname = cupNickname,
-        cupAmount = cupAmount,
-        cupRank = cupRank,
+        nickname = cupNickname,
+        amount = cupAmount,
+        rank = cupRank,
     )

--- a/android/app/src/main/java/com/mulkkam/domain/Cup.kt
+++ b/android/app/src/main/java/com/mulkkam/domain/Cup.kt
@@ -2,7 +2,14 @@ package com.mulkkam.domain
 
 data class Cup(
     val id: Int,
-    val cupNickname: String,
-    val cupAmount: Int,
-    val cupRank: Int,
-)
+    val nickname: String,
+    val amount: Int,
+    val rank: Int,
+) {
+    val isRepresentative: Boolean
+        get() = rank == REPRESENTATIVE_RANK
+
+    companion object {
+        private const val REPRESENTATIVE_RANK: Int = 1
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/domain/Cups.kt
+++ b/android/app/src/main/java/com/mulkkam/domain/Cups.kt
@@ -3,4 +3,11 @@ package com.mulkkam.domain
 data class Cups(
     val size: Int,
     val cups: List<Cup>,
-)
+) {
+    val isMaxSize: Boolean
+        get() = size >= MAX_CUP_SIZE
+
+    companion object {
+        const val MAX_CUP_SIZE: Int = 3
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/home/HomeViewModel.kt
@@ -21,8 +21,8 @@ class HomeViewModel : ViewModel() {
 
     fun addWaterIntake() {
         // TODO: 현재 cupRank가 2부터 들어가있음
-        val cup = cups?.cups?.find { it.cupRank == 2 }
-        val cupAmount = cup?.cupAmount
+        val cup = cups?.cups?.find { it.rank == 2 }
+        val cupAmount = cup?.amount
         _currentWaterIntake.value =
             (currentWaterIntake.value ?: 0) + (cupAmount ?: 0)
     }

--- a/android/app/src/main/java/com/mulkkam/ui/settingwater/SettingWaterActivity.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/settingwater/SettingWaterActivity.kt
@@ -3,14 +3,17 @@ package com.mulkkam.ui.settingwater
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import com.mulkkam.databinding.ActivitySettingWaterBinding
 import com.mulkkam.ui.binding.BindingActivity
 import com.mulkkam.ui.settingwater.adapter.SettingWaterAdapter
 import com.mulkkam.ui.settingwater.adapter.SettingWaterItem
 import com.mulkkam.ui.settingwater.dialog.SettingWaterCupFragment
 import com.mulkkam.ui.settingwater.model.CupUiModel
+import com.mulkkam.ui.settingwater.model.CupsUiModel
 
 class SettingWaterActivity : BindingActivity<ActivitySettingWaterBinding>(ActivitySettingWaterBinding::inflate) {
+    private val viewModel: SettingWaterViewModel by viewModels()
     private val settingWaterAdapter: SettingWaterAdapter by lazy {
         handleSettingWaterClick()
     }
@@ -19,6 +22,8 @@ class SettingWaterActivity : BindingActivity<ActivitySettingWaterBinding>(Activi
         super.onCreate(savedInstanceState)
         initClickListener()
         initCupItemsContainer()
+        initObserver()
+        viewModel.loadCups()
     }
 
     private fun handleSettingWaterClick() =
@@ -55,43 +60,24 @@ class SettingWaterActivity : BindingActivity<ActivitySettingWaterBinding>(Activi
 
     private fun initCupItemsContainer() {
         binding.rvSettingWater.adapter = settingWaterAdapter
-        settingWaterAdapter.submitList(DUMMY_CUP_ITEMS)
+    }
+
+    private fun initObserver() {
+        viewModel.cups.observe(this) { cups ->
+            showCups(cups)
+        }
+    }
+
+    private fun showCups(cups: CupsUiModel) {
+        val cupItems: List<SettingWaterItem> =
+            buildList {
+                addAll(cups.cups.map { SettingWaterItem.CupItem(it) })
+                if (cups.isAddable) add(SettingWaterItem.AddItem)
+            }
+        settingWaterAdapter.submitList(cupItems)
     }
 
     companion object {
         fun newIntent(context: Context): Intent = Intent(context, SettingWaterActivity::class.java)
-
-        private val DUMMY_CUP_ITEMS =
-            listOf(
-                SettingWaterItem.CupItem(
-                    value =
-                        CupUiModel(
-                            id = 8965,
-                            nickname = "스타벅스 텀블러",
-                            amount = 355,
-                            rank = 1,
-                            isRepresentative = true,
-                        ),
-                ),
-                SettingWaterItem.CupItem(
-                    value =
-                        CupUiModel(
-                            id = 1787,
-                            nickname = "우리집 컵",
-                            amount = 120,
-                            rank = 2,
-                        ),
-                ),
-                SettingWaterItem.CupItem(
-                    value =
-                        CupUiModel(
-                            id = 1234,
-                            nickname = "500ML 생맥주",
-                            amount = 500,
-                            rank = 3,
-                        ),
-                ),
-                SettingWaterItem.AddItem,
-            )
     }
 }

--- a/android/app/src/main/java/com/mulkkam/ui/settingwater/SettingWaterViewModel.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/settingwater/SettingWaterViewModel.kt
@@ -1,0 +1,25 @@
+package com.mulkkam.ui.settingwater
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mulkkam.di.RepositoryInjection.cupsRepository
+import com.mulkkam.ui.settingwater.model.CupsUiModel
+import com.mulkkam.ui.settingwater.model.toUi
+import kotlinx.coroutines.launch
+
+class SettingWaterViewModel : ViewModel() {
+    private var _cups: MutableLiveData<CupsUiModel> = MutableLiveData()
+    val cups: LiveData<CupsUiModel> get() = _cups
+
+    fun loadCups() {
+        viewModelScope.launch {
+            runCatching {
+                cupsRepository.getCups()
+            }.onSuccess {
+                _cups.value = it.toUi()
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/mulkkam/ui/settingwater/model/CupUiModel.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/settingwater/model/CupUiModel.kt
@@ -1,6 +1,7 @@
 package com.mulkkam.ui.settingwater.model
 
 import android.os.Parcelable
+import com.mulkkam.domain.Cup
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -9,7 +10,7 @@ data class CupUiModel(
     val nickname: String,
     val amount: Int,
     val rank: Int,
-    val isRepresentative: Boolean = false,
+    val isRepresentative: Boolean,
 ) : Parcelable {
     companion object {
         val EMPTY_CUP_UI_MODEL =
@@ -22,3 +23,12 @@ data class CupUiModel(
             )
     }
 }
+
+fun Cup.toUi(): CupUiModel =
+    CupUiModel(
+        id = id,
+        nickname = nickname,
+        amount = amount,
+        rank = rank,
+        isRepresentative = isRepresentative,
+    )

--- a/android/app/src/main/java/com/mulkkam/ui/settingwater/model/CupsUiModel.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/settingwater/model/CupsUiModel.kt
@@ -1,0 +1,14 @@
+package com.mulkkam.ui.settingwater.model
+
+import com.mulkkam.domain.Cups
+
+data class CupsUiModel(
+    val cups: List<CupUiModel>,
+    val isAddable: Boolean,
+)
+
+fun Cups.toUi(): CupsUiModel =
+    CupsUiModel(
+        cups = cups.map { cup -> cup.toUi() },
+        isAddable = isMaxSize.not(),
+    )


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #117

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 컵 수정 화면 API 연동

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 기존 Cup 모델 대표 여부 확인 로직 추가
2. 기존 Cups 모델 사이즈 확인 로직 추가
3. 컵 설정 API 연동

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/6e4fb119-34bc-47ea-9a7b-bfbcf7f0dc24

