### PR TITLE
[BE][chore] flyway 세팅

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,39 +1,40 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'backend'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.flywaydb:flyway-core'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/backend/src/main/java/backend/mulkkam/member/domain/Member.java
+++ b/backend/src/main/java/backend/mulkkam/member/domain/Member.java
@@ -33,7 +33,7 @@ public class Member {
     private PhysicalAttributes physicalAttributes;
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "targetAmount", nullable = false))
+    @AttributeOverride(name = "value", column = @Column(name = "target_amount", nullable = false))
     private Amount targetAmount;
 
     public void updateTargetAmount(Amount newTargetAmount) {

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -10,7 +10,15 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
+    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    validate-on-migrate: true
+    locations: classpath:db/migration
+    clean-disabled: true

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -4,15 +4,27 @@ server:
 spring:
   application:
     name: mulkkam
+
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL
     driver-class-name: org.h2.Driver
+    username: sa
+    password:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
-    defer-datasource-initialization: true
+      ddl-auto: none
+    open-in-view: false
+    defer-datasource-initialization: false
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+    validate-on-migrate: true
+    clean-disabled: true
 
   h2:
     console:
       enabled: true
+      path: /h2-console

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -4,9 +4,15 @@ spring:
     username: root
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+
+  flyway:
+    enabled: true
+    clean-disabled: false
+    locations: classpath:db/migration

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,28 @@
+CREATE TABLE member
+(
+    id            BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nickname      VARCHAR(10) NOT NULL UNIQUE,
+    gender        VARCHAR(255),
+    weight        DOUBLE,
+    target_amount INT         NOT NULL
+);
+
+CREATE TABLE cup
+(
+    id         BIGINT PRIMARY KEY AUTO_INCREMENT,
+    member_id  BIGINT      NOT NULL,
+    nickname   VARCHAR(10) NOT NULL,
+    cup_amount INT         NOT NULL,
+    cup_rank   INT         NOT NULL,
+    CONSTRAINT fk_cup_member FOREIGN KEY (member_id) REFERENCES member (id)
+);
+
+CREATE TABLE intake_history
+(
+    id            BIGINT PRIMARY KEY AUTO_INCREMENT,
+    member_id     BIGINT    NOT NULL,
+    date_time     TIMESTAMP NOT NULL,
+    intake_amount INT       NOT NULL,
+    target_amount INT       NOT NULL,
+    CONSTRAINT fk_intake_history_member FOREIGN KEY (member_id) REFERENCES member (id)
+);


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #147 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- ci 용 yml 수정
- local 용 yml 수정
- dev 용 yml 수정
- V1__init.sql 작성

### 간략한 설명

앞으로 자신이 담당한 작업 범위에서 엔티티 변경이 포함된다면, 다음과 같이 파일을 생성하면 됩니다!
`/resources/db/migration` 아래에 V<`버전`>__<`버전에 대한 설명`>.sql 을 생성합니다. 반드시 언더바는 두개!
ex) 추후 멤버 필드에 age 라는 필드가 추가된다면 `V2__add_age_in_member.sql` 이런식!

flyway 가 작동하면 데이터베이스에서는 내부에 `flyway_schema_history` 가 생성됩니다.
해당 테이블에는 어느 버전까지 마이그레이션이 됐는지 저장하고, 그 이후로부터 스크립트가 실행됩니다.

---

```yml
flyway:
  enabled: true
  baseline-on-migrate: true
  validate-on-migrate: true
  locations: classpath:db/migration
  clean-disabled: true
```

- baseline-on-migrate : 초기 설정에 사용됩니다. `flyway_schema_history` 가 기존에 없더라도 오류가 나지 않습니다.
- validate-on-migrate: 과거의 스크립트가 수정되면 체크섬 오류가 납니다.
- clean-disabled: 모든 테이블들을 drop 할 수 있는 기능을 끕니다.
