### PR TITLE
[BE][fix] mysql 인식을 위한 의존성 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,7 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-core:10.12.0'
+    implementation 'org.flywaydb:flyway-mysql:10.12.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #147 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 배포 환경에서 mysql 이 인식되지 않는 오류를 해결하기 위해 mysql 관련 의존성 추가
```
implementation 'org.flywaydb:flyway-mysql:10.12.0'
```
