### PR TITLE
[BE][feat] 사용자 홈 정보 반환 기능 구현

### DIFF
--- a/backend/src/main/java/backend/mulkkam/intake/repository/IntakeHistoryRepository.java
+++ b/backend/src/main/java/backend/mulkkam/intake/repository/IntakeHistoryRepository.java
@@ -1,9 +1,12 @@
 package backend.mulkkam.intake.repository;
 
 import backend.mulkkam.intake.domain.IntakeHistory;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IntakeHistoryRepository extends JpaRepository<IntakeHistory, Long> {
     List<IntakeHistory> findAllByMemberId(Long memberId);
@@ -13,4 +16,20 @@ public interface IntakeHistoryRepository extends JpaRepository<IntakeHistory, Lo
             LocalDateTime dateTimeAfter,
             LocalDateTime dateTimeBefore
     );
+
+    @Query(value = """
+            SELECT COUNT(*) AS consecutive_days
+            FROM (
+                SELECT 
+                    DATE(date_time) AS record_date,
+                    ROW_NUMBER() OVER (ORDER BY DATE(date_time) DESC) AS rn
+                FROM intake_history
+                WHERE member_id = :memberId
+                  AND DATE(date_time) <= :baseDate
+                GROUP BY DATE(date_time)
+            ) AS sub
+            WHERE DATEDIFF(:baseDate, record_date) = rn - 1
+            """, nativeQuery = true)
+    int countConsecutiveDays(@Param("memberId") Long memberId,
+                             @Param("baseDate") LocalDate baseDate);
 }

--- a/backend/src/main/java/backend/mulkkam/member/controller/MemberController.java
+++ b/backend/src/main/java/backend/mulkkam/member/controller/MemberController.java
@@ -1,12 +1,17 @@
 package backend.mulkkam.member.controller;
 
-import backend.mulkkam.member.dto.PhysicalAttributesModifyRequest;
+import backend.mulkkam.intake.dto.DateRangeRequest;
+import backend.mulkkam.member.dto.request.PhysicalAttributesModifyRequest;
+import backend.mulkkam.member.dto.response.ProgressInfoResponse;
 import backend.mulkkam.member.service.MemberService;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -17,11 +22,18 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/physical-attributes")
-    public ResponseEntity<Void> modifyPhysicalAttributes(@RequestBody PhysicalAttributesModifyRequest physicalAttributesModifyRequest) {
+    public ResponseEntity<Void> modifyPhysicalAttributes(
+            @RequestBody PhysicalAttributesModifyRequest physicalAttributesModifyRequest) {
         memberService.modifyPhysicalAttributes(
                 physicalAttributesModifyRequest,
                 1L
         );
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/members/progress-info")
+    public ResponseEntity<ProgressInfoResponse> getProgressInfo(@RequestParam LocalDate date) {
+        DateRangeRequest dateRangeRequest = new DateRangeRequest(date, date);
+        return ResponseEntity.ok(memberService.getTodayProgressInfo(dateRangeRequest, 1L));
     }
 }

--- a/backend/src/main/java/backend/mulkkam/member/dto/request/PhysicalAttributesModifyRequest.java
+++ b/backend/src/main/java/backend/mulkkam/member/dto/request/PhysicalAttributesModifyRequest.java
@@ -1,4 +1,4 @@
-package backend.mulkkam.member.dto;
+package backend.mulkkam.member.dto.request;
 
 import backend.mulkkam.member.domain.vo.Gender;
 import backend.mulkkam.member.domain.vo.PhysicalAttributes;

--- a/backend/src/main/java/backend/mulkkam/member/dto/response/ProgressInfoResponse.java
+++ b/backend/src/main/java/backend/mulkkam/member/dto/response/ProgressInfoResponse.java
@@ -1,0 +1,10 @@
+package backend.mulkkam.member.dto.response;
+
+public record ProgressInfoResponse(
+        String memberNickname,
+        int streak,
+        Double achievementRate,
+        Integer targetAmount,
+        Integer totalAmount
+) {
+}

--- a/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
+++ b/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
@@ -2,9 +2,15 @@ package backend.mulkkam.member.service;
 
 import backend.mulkkam.common.exception.CommonException;
 import backend.mulkkam.common.exception.errorCode.NotFoundErrorCode;
+import backend.mulkkam.intake.dto.DateRangeRequest;
+import backend.mulkkam.intake.dto.IntakeHistorySummaryResponse;
+import backend.mulkkam.intake.repository.IntakeHistoryRepository;
+import backend.mulkkam.intake.service.IntakeHistoryService;
 import backend.mulkkam.member.domain.Member;
-import backend.mulkkam.member.dto.PhysicalAttributesModifyRequest;
+import backend.mulkkam.member.dto.request.PhysicalAttributesModifyRequest;
+import backend.mulkkam.member.dto.response.ProgressInfoResponse;
 import backend.mulkkam.member.repository.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-
+    private final IntakeHistoryRepository intakeHistoryRepository;
+    private final IntakeHistoryService intakeHistoryService;
 
     @Transactional
     public void modifyPhysicalAttributes(
@@ -24,6 +31,49 @@ public class MemberService {
     ) {
         Member member = getById(memberId);
         member.updatePhysicalAttributes(physicalAttributesModifyRequest.toPhysicalAttributes());
+    }
+
+    public ProgressInfoResponse getTodayProgressInfo(DateRangeRequest date, Long memberId) {
+        Member member = getById(memberId);
+        String nickname = member.getMemberNickname().value();
+        int targetAmount = member.getTargetAmount().value();
+
+        List<IntakeHistorySummaryResponse> summaries = intakeHistoryService.readSummaryOfIntakeHistories(
+                date,
+                memberId
+        );
+        int streak = intakeHistoryRepository.countConsecutiveDays(memberId, date.from());
+        return buildProgressInfoResponse(
+                nickname,
+                targetAmount,
+                streak,
+                summaries
+        );
+    }
+
+    private ProgressInfoResponse buildProgressInfoResponse(
+            String nickname,
+            int targetAmount,
+            int streak,
+            List<IntakeHistorySummaryResponse> summaries
+    ) {
+        if (summaries.isEmpty()) {
+            return new ProgressInfoResponse(
+                    nickname,
+                    streak,
+                    0.0,
+                    targetAmount,
+                    0
+            );
+        }
+        IntakeHistorySummaryResponse summary = summaries.getFirst();
+        return new ProgressInfoResponse(
+                nickname,
+                streak,
+                summary.achievementRate(),
+                summary.targetAmount(),
+                summary.totalIntakeAmount()
+        );
     }
 
     private Member getById(Long id) {

--- a/backend/src/test/java/backend/mulkkam/member/service/MemberServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/service/MemberServiceIntegrationTest.java
@@ -1,17 +1,26 @@
 package backend.mulkkam.member.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import backend.mulkkam.intake.domain.IntakeHistory;
+import backend.mulkkam.intake.dto.DateRangeRequest;
+import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.domain.vo.Gender;
-import backend.mulkkam.member.dto.PhysicalAttributesModifyRequest;
+import backend.mulkkam.member.dto.request.PhysicalAttributesModifyRequest;
+import backend.mulkkam.member.dto.response.ProgressInfoResponse;
 import backend.mulkkam.member.repository.MemberRepository;
+import backend.mulkkam.support.IntakeHistoryFixtureBuilder;
 import backend.mulkkam.support.MemberFixtureBuilder;
 import backend.mulkkam.support.ServiceIntegrationTest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class MemberServiceIntegrationTest extends ServiceIntegrationTest {
 
@@ -20,6 +29,9 @@ class MemberServiceIntegrationTest extends ServiceIntegrationTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private IntakeHistoryRepository intakeHistoryRepository;
 
     @DisplayName("멤버의 신체적인 속성 값을 수정할 때")
     @Nested
@@ -57,6 +69,64 @@ class MemberServiceIntegrationTest extends ServiceIntegrationTest {
                 softly.assertThat(result.getPhysicalAttributes().getWeight()).isEqualTo(weight);
                 softly.assertThat(result.getTargetAmount()).isEqualTo(member.getTargetAmount());
             });
+        }
+    }
+
+    @DisplayName("멤버의 금일 활동 정보를 가져올 때")
+    @Nested
+    class Get {
+
+        @DisplayName("정상적으로 가져온다")
+        @Test
+        void success_validDataAllArgs() {
+            // given
+            Member member = MemberFixtureBuilder
+                    .builder()
+                    .build();
+            memberRepository.save(member);
+
+            IntakeHistory intakeHistory1 = IntakeHistoryFixtureBuilder
+                    .withMember(member)
+                    .dateTime(LocalDateTime.of(2025, 7, 25, 15, 5))
+                    .build();
+            IntakeHistory intakeHistory2 = IntakeHistoryFixtureBuilder
+                    .withMember(member)
+                    .dateTime(LocalDateTime.of(2025, 7, 25, 15, 30))
+                    .build();
+            IntakeHistory intakeHistory3 = IntakeHistoryFixtureBuilder
+                    .withMember(member)
+                    .dateTime(LocalDateTime.of(2025, 7, 24, 15, 5))
+                    .build();
+            IntakeHistory intakeHistory4 = IntakeHistoryFixtureBuilder
+                    .withMember(member)
+                    .dateTime(LocalDateTime.of(2025, 7, 23, 15, 5))
+                    .build();
+            IntakeHistory intakeHistory5 = IntakeHistoryFixtureBuilder
+                    .withMember(member)
+                    .dateTime(LocalDateTime.of(2025, 7, 21, 15, 5))
+                    .build();
+
+            intakeHistoryRepository.saveAll(List.of(
+                    intakeHistory1,
+                    intakeHistory2,
+                    intakeHistory3,
+                    intakeHistory4,
+                    intakeHistory5
+            ));
+
+            DateRangeRequest dateRangeRequest = new DateRangeRequest(
+                    LocalDate.of(2025, 7, 25),
+                    LocalDate.of(2025, 7, 25)
+            );
+
+            ProgressInfoResponse progressInfoResponse = memberService.getTodayProgressInfo(
+                    dateRangeRequest,
+                    member.getId()
+            );
+
+            assertSoftly(
+                    softAssertions -> assertThat(progressInfoResponse.streak()).isEqualTo(3)
+            );
         }
     }
 }

--- a/backend/src/test/java/backend/mulkkam/member/service/MemberServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/service/MemberServiceUnitTest.java
@@ -1,8 +1,11 @@
 package backend.mulkkam.member.service;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.when;
+
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.domain.vo.Gender;
-import backend.mulkkam.member.dto.PhysicalAttributesModifyRequest;
+import backend.mulkkam.member.dto.request.PhysicalAttributesModifyRequest;
 import backend.mulkkam.member.repository.MemberRepository;
 import backend.mulkkam.support.MemberFixtureBuilder;
 import java.util.Optional;
@@ -13,9 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceUnitTest {


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #169 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 사용자의 홈 정보를 반환합니다. (이름, 스트릭, 금일 성공률, 금일 음용량, 금일 목표 음용량


**주의**
**현재 H2와 MySQL 차이로 인해 CI로 테스트합니다.**


### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->
