### PR TITLE
[BE][feat]: 사용자 컵에 음용 타입 추가

### DIFF
--- a/backend/src/main/java/backend/mulkkam/cup/controller/CupController.java
+++ b/backend/src/main/java/backend/mulkkam/cup/controller/CupController.java
@@ -1,7 +1,7 @@
 package backend.mulkkam.cup.controller;
 
-import backend.mulkkam.cup.dto.request.CupNicknameAndAmountModifyRequest;
-import backend.mulkkam.cup.dto.request.CupRegisterRequest;
+import backend.mulkkam.cup.dto.request.RegisterCupRequest;
+import backend.mulkkam.cup.dto.request.UpdateCupRequest;
 import backend.mulkkam.cup.dto.response.CupsResponse;
 import backend.mulkkam.cup.service.CupService;
 import lombok.RequiredArgsConstructor;
@@ -27,9 +27,9 @@ public class CupController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody CupRegisterRequest cupRegisterRequest) {
+    public ResponseEntity<Void> create(@RequestBody RegisterCupRequest registerCupRequest) {
         cupService.create(
-                cupRegisterRequest,
+                registerCupRequest,
                 1L
         );
         return ResponseEntity.ok().build();
@@ -37,13 +37,13 @@ public class CupController {
 
     @PatchMapping("/{cupId}")
     public ResponseEntity<Void> modifyNicknameAndAmount(
-            @RequestBody CupNicknameAndAmountModifyRequest cupNicknameAndAmountModifyRequest,
+            @RequestBody UpdateCupRequest updateCupRequest,
             @PathVariable Long cupId
     ) {
-        cupService.modifyNicknameAndAmount(
+        cupService.update(
                 cupId,
                 1L,
-                cupNicknameAndAmountModifyRequest
+                updateCupRequest
         );
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/backend/mulkkam/cup/domain/Cup.java
+++ b/backend/src/main/java/backend/mulkkam/cup/domain/Cup.java
@@ -9,6 +9,8 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -54,23 +56,30 @@ public class Cup {
     )
     private CupRank cupRank;
 
+    @Enumerated(EnumType.STRING)
+    private IntakeType intakeType;
+
     public Cup(
             Member member,
             CupNickname nickname,
             CupAmount cupAmount,
-            CupRank cupRank
+            CupRank cupRank,
+            IntakeType intakeType
     ) {
         this.member = member;
         this.nickname = nickname;
         this.cupAmount = cupAmount;
         this.cupRank = cupRank;
+        this.intakeType = intakeType;
     }
 
     public void modifyNicknameAndAmount(
             CupNickname nickname,
-            CupAmount cupAmount
+            CupAmount cupAmount,
+            IntakeType intakeType
     ) {
         this.nickname = nickname;
         this.cupAmount = cupAmount;
+        this.intakeType = intakeType;
     }
 }

--- a/backend/src/main/java/backend/mulkkam/cup/domain/IntakeType.java
+++ b/backend/src/main/java/backend/mulkkam/cup/domain/IntakeType.java
@@ -1,0 +1,8 @@
+package backend.mulkkam.cup.domain;
+
+public enum IntakeType {
+
+    WATER,
+    COFFEE,
+    ;
+}

--- a/backend/src/main/java/backend/mulkkam/cup/dto/request/CupNicknameAndAmountModifyRequest.java
+++ b/backend/src/main/java/backend/mulkkam/cup/dto/request/CupNicknameAndAmountModifyRequest.java
@@ -1,7 +1,0 @@
-package backend.mulkkam.cup.dto.request;
-
-public record CupNicknameAndAmountModifyRequest(
-        String cupNickname,
-        Integer cupAmount
-) {
-}

--- a/backend/src/main/java/backend/mulkkam/cup/dto/request/RegisterCupRequest.java
+++ b/backend/src/main/java/backend/mulkkam/cup/dto/request/RegisterCupRequest.java
@@ -1,14 +1,16 @@
 package backend.mulkkam.cup.dto.request;
 
 import backend.mulkkam.cup.domain.Cup;
+import backend.mulkkam.cup.domain.IntakeType;
 import backend.mulkkam.cup.domain.vo.CupAmount;
 import backend.mulkkam.cup.domain.vo.CupNickname;
 import backend.mulkkam.cup.domain.vo.CupRank;
 import backend.mulkkam.member.domain.Member;
 
-public record CupRegisterRequest(
+public record RegisterCupRequest(
         String cupNickname,
-        Integer cupAmount
+        Integer cupAmount,
+        IntakeType intakeType
 ) {
 
     public Cup toCup(
@@ -19,7 +21,8 @@ public record CupRegisterRequest(
                 member,
                 new CupNickname(cupNickname),
                 new CupAmount(cupAmount),
-                cupRank
+                cupRank,
+                intakeType
         );
     }
 }

--- a/backend/src/main/java/backend/mulkkam/cup/dto/request/UpdateCupRequest.java
+++ b/backend/src/main/java/backend/mulkkam/cup/dto/request/UpdateCupRequest.java
@@ -1,0 +1,10 @@
+package backend.mulkkam.cup.dto.request;
+
+import backend.mulkkam.cup.domain.IntakeType;
+
+public record UpdateCupRequest(
+        String cupNickname,
+        Integer cupAmount,
+        IntakeType intakeType
+) {
+}

--- a/backend/src/main/java/backend/mulkkam/cup/dto/response/CupResponse.java
+++ b/backend/src/main/java/backend/mulkkam/cup/dto/response/CupResponse.java
@@ -1,12 +1,14 @@
 package backend.mulkkam.cup.dto.response;
 
 import backend.mulkkam.cup.domain.Cup;
+import backend.mulkkam.cup.domain.IntakeType;
 
 public record CupResponse(
         Long id,
         String cupNickname,
         Integer cupAmount,
-        Integer cupRank
+        Integer cupRank,
+        IntakeType intakeType
 ) {
 
     public CupResponse(Cup cup) {
@@ -14,7 +16,8 @@ public record CupResponse(
                 cup.getId(),
                 cup.getNickname().value(),
                 cup.getCupAmount().value(),
-                cup.getCupRank().value()
+                cup.getCupRank().value(),
+                cup.getIntakeType()
         );
     }
 }

--- a/backend/src/main/java/backend/mulkkam/cup/service/CupService.java
+++ b/backend/src/main/java/backend/mulkkam/cup/service/CupService.java
@@ -9,8 +9,8 @@ import backend.mulkkam.cup.domain.Cup;
 import backend.mulkkam.cup.domain.vo.CupAmount;
 import backend.mulkkam.cup.domain.vo.CupNickname;
 import backend.mulkkam.cup.domain.vo.CupRank;
-import backend.mulkkam.cup.dto.request.CupNicknameAndAmountModifyRequest;
-import backend.mulkkam.cup.dto.request.CupRegisterRequest;
+import backend.mulkkam.cup.dto.request.RegisterCupRequest;
+import backend.mulkkam.cup.dto.request.UpdateCupRequest;
 import backend.mulkkam.cup.dto.response.CupResponse;
 import backend.mulkkam.cup.dto.response.CupsResponse;
 import backend.mulkkam.cup.repository.CupRepository;
@@ -31,13 +31,13 @@ public class CupService {
 
     @Transactional
     public CupResponse create(
-            CupRegisterRequest cupRegisterRequest,
+            RegisterCupRequest registerCupRequest,
             Long memberId
     ) {
         Member member = getMember(memberId);
         List<Cup> cups = cupRepository.findAllByMemberIdOrderByCupRankAsc(memberId);
         CupRank currentCupRank = new CupRank(cups.size());
-        Cup cup = cupRegisterRequest.toCup(
+        Cup cup = registerCupRequest.toCup(
                 member,
                 currentCupRank.nextRank()
         );
@@ -52,18 +52,19 @@ public class CupService {
     }
 
     @Transactional
-    public void modifyNicknameAndAmount(
+    public void update(
             Long id,
             Long memberId,
-            CupNicknameAndAmountModifyRequest cupNicknameAndAmountModifyRequest
+            UpdateCupRequest updateCupRequest
     ) {
         Member member = getMember(memberId);
         Cup cup = getCup(id);
 
         validateCupOwnership(member, cup);
         cup.modifyNicknameAndAmount(
-                new CupNickname(cupNicknameAndAmountModifyRequest.cupNickname()),
-                new CupAmount(cupNicknameAndAmountModifyRequest.cupAmount())
+                new CupNickname(updateCupRequest.cupNickname()),
+                new CupAmount(updateCupRequest.cupAmount()),
+                updateCupRequest.intakeType()
         );
     }
 

--- a/backend/src/main/resources/db/migration/V2__update_cup_table.sql
+++ b/backend/src/main/resources/db/migration/V2__update_cup_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cup
+    ADD COLUMN intake_type VARCHAR(10);

--- a/backend/src/test/java/backend/mulkkam/support/CupFixtureBuilder.java
+++ b/backend/src/test/java/backend/mulkkam/support/CupFixtureBuilder.java
@@ -1,6 +1,7 @@
 package backend.mulkkam.support;
 
 import backend.mulkkam.cup.domain.Cup;
+import backend.mulkkam.cup.domain.IntakeType;
 import backend.mulkkam.cup.domain.vo.CupAmount;
 import backend.mulkkam.cup.domain.vo.CupNickname;
 import backend.mulkkam.cup.domain.vo.CupRank;
@@ -12,6 +13,7 @@ public class CupFixtureBuilder {
     private CupNickname cupNickname = new CupNickname("스타벅스");
     private CupAmount cupAmount = new CupAmount(500);
     private CupRank cupRank = new CupRank(1);
+    private IntakeType intakeType = IntakeType.WATER;
 
     private CupFixtureBuilder(Member member) {
         this.member = member;
@@ -36,7 +38,12 @@ public class CupFixtureBuilder {
         return this;
     }
 
+    public CupFixtureBuilder intakeType(IntakeType intakeType) {
+        this.intakeType = intakeType;
+        return this;
+    }
+
     public Cup build() {
-        return new Cup(member, cupNickname, cupAmount, cupRank);
+        return new Cup(member, cupNickname, cupAmount, cupRank, intakeType);
     }
 }


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #189 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 사용자 컵에 음용 타입을 추가합니다. (현재로서는 물과 커피가 있습니다.)
- 사용자 컵에 대한 추가 및 수정 로직을 수정합니다.
- 테스트 코드를 수정합니다.

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->
