### PR TITLE
[BE][fix]: 음용량 기록 삭제 기능 수정

### DIFF
--- a/backend/src/main/java/backend/mulkkam/common/exception/errorCode/NotFoundErrorCode.java
+++ b/backend/src/main/java/backend/mulkkam/common/exception/errorCode/NotFoundErrorCode.java
@@ -9,6 +9,7 @@ public enum NotFoundErrorCode implements ErrorCode {
     NOT_FOUND_INTAKE_TYPE,
     NOT_FOUND_INTAKE_HISTORY,
     NOT_FOUND_DEVICE,
+    NOT_FOUND_INTAKE_HISTORY_DETAIL,
     ;
 
     private static final HttpStatus status = HttpStatus.NOT_FOUND;

--- a/backend/src/main/java/backend/mulkkam/intake/controller/IntakeHistoryController.java
+++ b/backend/src/main/java/backend/mulkkam/intake/controller/IntakeHistoryController.java
@@ -46,9 +46,9 @@ public class IntakeHistoryController {
         return ResponseEntity.ok(createIntakeHistoryResponse);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        intakeHistoryService.delete(id, 1L);
+    @DeleteMapping("/details/{id}")
+    public ResponseEntity<Void> deleteDetailHistory(@PathVariable Long id) {
+        intakeHistoryService.deleteDetailHistory(id, 1L);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/domain/IntakeHistoryDetail.java
+++ b/backend/src/main/java/backend/mulkkam/intake/domain/IntakeHistoryDetail.java
@@ -1,6 +1,7 @@
 package backend.mulkkam.intake.domain;
 
 import backend.mulkkam.intake.domain.vo.Amount;
+import backend.mulkkam.member.domain.Member;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -11,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,5 +45,13 @@ public class IntakeHistoryDetail {
         this.intakeTime = intakeTime;
         this.intakeAmount = intakeAmount;
         this.intakeHistory = intakeHistory;
+    }
+
+    public boolean isOwnedBy(Member comparedMember) {
+        return this.intakeHistory.isOwnedBy(comparedMember);
+    }
+
+    public boolean isCreatedAt(LocalDate comparedDate) {
+        return this.intakeHistory.isCreatedAt(comparedDate);
     }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/repository/IntakeDetailRepository.java
+++ b/backend/src/main/java/backend/mulkkam/intake/repository/IntakeDetailRepository.java
@@ -3,6 +3,7 @@ package backend.mulkkam.intake.repository;
 import backend.mulkkam.intake.domain.IntakeHistoryDetail;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +20,13 @@ public interface IntakeDetailRepository extends JpaRepository<IntakeHistoryDetai
             @Param("dateAfter") LocalDate dateAfter,
             @Param("dateBefore") LocalDate dateBefore
     );
+
+    @Query("""
+                SELECT d
+                FROM IntakeHistoryDetail d
+                JOIN FETCH d.intakeHistory h
+                JOIN FETCH h.member
+                WHERE d.id = :id
+            """)
+    Optional<IntakeHistoryDetail> findWithHistoryAndMemberById(@Param("id") Long id);
 }

--- a/backend/src/main/java/backend/mulkkam/intake/repository/IntakeHistoryDetailRepository.java
+++ b/backend/src/main/java/backend/mulkkam/intake/repository/IntakeHistoryDetailRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface IntakeDetailRepository extends JpaRepository<IntakeHistoryDetail, Long> {
+public interface IntakeHistoryDetailRepository extends JpaRepository<IntakeHistoryDetail, Long> {
 
     @Query("SELECT d FROM IntakeHistoryDetail d " +
             "JOIN d.intakeHistory h " +

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -12,7 +12,7 @@ import backend.mulkkam.intake.dto.request.DateRangeRequest;
 import backend.mulkkam.intake.dto.request.IntakeDetailCreateRequest;
 import backend.mulkkam.intake.dto.response.IntakeDetailResponse;
 import backend.mulkkam.intake.dto.response.IntakeHistorySummaryResponse;
-import backend.mulkkam.intake.repository.IntakeDetailRepository;
+import backend.mulkkam.intake.repository.IntakeHistoryDetailRepository;
 import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.repository.MemberRepository;
@@ -39,7 +39,7 @@ public class IntakeHistoryService {
 
     private final IntakeHistoryRepository intakeHistoryRepository;
     private final MemberRepository memberRepository;
-    private final IntakeDetailRepository intakeDetailRepository;
+    private final IntakeHistoryDetailRepository intakeHistoryDetailRepository;
 
     @Transactional
     public CreateIntakeHistoryResponse create(
@@ -63,7 +63,7 @@ public class IntakeHistoryService {
                     return intakeHistoryRepository.save(newIntakeHistory);
                 });
         IntakeHistoryDetail intakeHistoryDetail = intakeDetailCreateRequest.toIntakeDetail(intakeHistory);
-        intakeDetailRepository.save(intakeHistoryDetail);
+        intakeHistoryDetailRepository.save(intakeHistoryDetail);
 
         List<IntakeHistoryDetail> intakeHistoryDetails = findIntakeHistoriesOfDate(
                 intakeDetailCreateRequest.dateTime().toLocalDate(),
@@ -94,7 +94,7 @@ public class IntakeHistoryService {
             Long memberId
     ) {
         Member member = getMember(memberId);
-        List<IntakeHistoryDetail> details = intakeDetailRepository.findAllByMemberIdAndDateRange(
+        List<IntakeHistoryDetail> details = intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(
                 memberId,
                 dateRangeRequest.from(),
                 dateRangeRequest.to()
@@ -120,7 +120,7 @@ public class IntakeHistoryService {
                 intakeHistoryDetailId);
 
         validatePossibleToDelete(intakeHistoryDetail, member);
-        intakeDetailRepository.delete(intakeHistoryDetail);
+        intakeHistoryDetailRepository.delete(intakeHistoryDetail);
     }
 
     private void validatePossibleToDelete(
@@ -146,7 +146,7 @@ public class IntakeHistoryService {
             LocalDate date,
             Long memberId
     ) {
-        return intakeDetailRepository.findAllByMemberIdAndDateRange(
+        return intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(
                 memberId,
                 date,
                 date
@@ -210,7 +210,7 @@ public class IntakeHistoryService {
     }
 
     private IntakeHistoryDetail findIntakeHistoryDetailByIdWithHistoryAndMember(Long id) {
-        return intakeDetailRepository.findWithHistoryAndMemberById(id)
+        return intakeHistoryDetailRepository.findWithHistoryAndMemberById(id)
                 .orElseThrow(() -> new CommonException(NOT_FOUND_INTAKE_HISTORY_DETAIL));
     }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_DATE_FOR_DELETE_INTAKE_HISTORY;
 import static backend.mulkkam.common.exception.errorCode.ForbiddenErrorCode.NOT_PERMITTED_FOR_INTAKE_HISTORY;
 import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY;
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY_DETAIL;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -110,27 +111,28 @@ public class IntakeHistoryService {
     }
 
     @Transactional
-    public void delete(
-            Long intakeHistoryId,
+    public void deleteDetailHistory(
+            Long intakeHistoryDetailId,
             Long memberId
     ) {
         Member member = getMember(memberId);
-        IntakeHistory intakeHistory = findById(intakeHistoryId);
+        IntakeHistoryDetail intakeHistoryDetail = findIntakeHistoryDetailByIdWithHistoryAndMember(
+                intakeHistoryDetailId);
 
-        validatePossibleToDelete(intakeHistory, member);
-        intakeHistoryRepository.delete(intakeHistory);
+        validatePossibleToDelete(intakeHistoryDetail, member);
+        intakeDetailRepository.delete(intakeHistoryDetail);
     }
 
     private void validatePossibleToDelete(
-            IntakeHistory intakeHistory,
+            IntakeHistoryDetail intakeHistoryDetail,
             Member member
     ) {
-        if (!intakeHistory.isOwnedBy(member)) {
+        if (!intakeHistoryDetail.isOwnedBy(member)) {
             throw new CommonException(NOT_PERMITTED_FOR_INTAKE_HISTORY);
         }
 
         LocalDate today = LocalDate.now();
-        if (!intakeHistory.isCreatedAt(today)) {
+        if (!intakeHistoryDetail.isCreatedAt(today)) {
             throw new CommonException(INVALID_DATE_FOR_DELETE_INTAKE_HISTORY);
         }
     }
@@ -205,5 +207,10 @@ public class IntakeHistoryService {
     private IntakeHistory findById(Long id) {
         return intakeHistoryRepository.findById(id)
                 .orElseThrow(() -> new CommonException(NOT_FOUND_INTAKE_HISTORY));
+    }
+
+    private IntakeHistoryDetail findIntakeHistoryDetailByIdWithHistoryAndMember(Long id) {
+        return intakeDetailRepository.findWithHistoryAndMemberById(id)
+                .orElseThrow(() -> new CommonException(NOT_FOUND_INTAKE_HISTORY_DETAIL));
     }
 }

--- a/backend/src/test/java/backend/mulkkam/intake/repository/IntakeHistoryDetailRepositoryTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/repository/IntakeHistoryDetailRepositoryTest.java
@@ -28,7 +28,7 @@ public class IntakeHistoryDetailRepositoryTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private IntakeDetailRepository intakeDetailRepository;
+    private IntakeHistoryDetailRepository intakeHistoryDetailRepository;
 
     @DisplayName("음용 세부 기록을 조회할 때에")
     @Nested
@@ -76,20 +76,20 @@ public class IntakeHistoryDetailRepositoryTest {
                     .time(LocalTime.of(13, 0))
                     .build();
 
-            intakeDetailRepository.saveAll(
+            intakeHistoryDetailRepository.saveAll(
                     List.of(firstIntakeDetail, secondIntakeDetail, thirdIntakeDetail, fourthIntakeDetail));
 
             // when
-            List<IntakeHistoryDetail> firstDetails = intakeDetailRepository.findAllByMemberIdAndDateRange(
+            List<IntakeHistoryDetail> firstDetails = intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(
                     member.getId(),
                     date,
                     date
             );
-            List<IntakeHistoryDetail> secondDetails = intakeDetailRepository.findAllByMemberIdAndDateRange(
+            List<IntakeHistoryDetail> secondDetails = intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(
                     member.getId(),
                     date.plusDays(1),
                     date.plusDays(1));
-            List<IntakeHistoryDetail> allDetails = intakeDetailRepository.findAllByMemberIdAndDateRange(member.getId(),
+            List<IntakeHistoryDetail> allDetails = intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(member.getId(),
                     date,
                     date.plusDays(1));
 

--- a/backend/src/test/java/backend/mulkkam/intake/repository/IntakeHistoryDetailRepositoryTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/repository/IntakeHistoryDetailRepositoryTest.java
@@ -6,7 +6,7 @@ import backend.mulkkam.intake.domain.IntakeHistory;
 import backend.mulkkam.intake.domain.IntakeHistoryDetail;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.repository.MemberRepository;
-import backend.mulkkam.support.IntakeDetailFixtureBuilder;
+import backend.mulkkam.support.IntakeHistoryDetailFixtureBuilder;
 import backend.mulkkam.support.IntakeHistoryFixtureBuilder;
 import backend.mulkkam.support.MemberFixtureBuilder;
 import java.time.LocalDate;
@@ -56,22 +56,22 @@ public class IntakeHistoryDetailRepositoryTest {
                     .build();
             intakeHistoryRepository.save(secondIntakeHistory);
 
-            IntakeHistoryDetail firstIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail firstIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(firstIntakeHistory)
                     .time(LocalTime.of(10, 0))
                     .build();
 
-            IntakeHistoryDetail secondIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail secondIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(firstIntakeHistory)
                     .time(LocalTime.of(11, 0))
                     .build();
 
-            IntakeHistoryDetail thirdIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail thirdIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(secondIntakeHistory)
                     .time(LocalTime.of(15, 0))
                     .build();
 
-            IntakeHistoryDetail fourthIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail fourthIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(secondIntakeHistory)
                     .time(LocalTime.of(13, 0))
                     .build();

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_AMOUNT;
 import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_DATE_FOR_DELETE_INTAKE_HISTORY;
 import static backend.mulkkam.common.exception.errorCode.ForbiddenErrorCode.NOT_PERMITTED_FOR_INTAKE_HISTORY;
-import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY;
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY_DETAIL;
 import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -355,13 +355,13 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
         }
     }
 
-    @DisplayName("음용 기록을 삭제할 때에")
+    @DisplayName("음용 세부 기록을 삭제할 때에")
     @Nested
     class Delete {
 
         @DisplayName("존재하지 않는 기록에 대한 요청인 경우 예외가 발생한다")
         @Test
-        void error_historyIsNotExisted() {
+        void error_historyDetailIsNotExisted() {
             // given
             Member member = MemberFixtureBuilder
                     .builder()
@@ -369,9 +369,9 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             memberRepository.save(member);
 
             // when & then
-            assertThatThrownBy(() -> intakeHistoryService.delete(1L, member.getId()))
+            assertThatThrownBy(() -> intakeHistoryService.deleteDetailHistory(1L, member.getId()))
                     .isInstanceOf(CommonException.class)
-                    .hasMessage(NOT_FOUND_INTAKE_HISTORY.name());
+                    .hasMessage(NOT_FOUND_INTAKE_HISTORY_DETAIL.name());
         }
 
         @DisplayName("존재하지 않는 멤버에 대한 요청인 경우 예외가 발생한다")
@@ -389,8 +389,14 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
+            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+                    .withIntakeHistory(intakeHistory)
+                    .build();
+            intakeDetailRepository.save(intakeHistoryDetail);
+
             // when & then
-            assertThatThrownBy(() -> intakeHistoryService.delete(intakeHistory.getId(), member.getId() + 1L))
+            assertThatThrownBy(
+                    () -> intakeHistoryService.deleteDetailHistory(intakeHistory.getId(), member.getId() + 1L))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(NOT_FOUND_MEMBER.name());
         }
@@ -416,13 +422,19 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
+            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+                    .withIntakeHistory(intakeHistory)
+                    .build();
+            intakeDetailRepository.save(intakeHistoryDetail);
+
             // when & then
-            assertThatThrownBy(() -> intakeHistoryService.delete(intakeHistory.getId(), savedAnotherMember.getId()))
+            assertThatThrownBy(
+                    () -> intakeHistoryService.deleteDetailHistory(intakeHistory.getId(), savedAnotherMember.getId()))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(NOT_PERMITTED_FOR_INTAKE_HISTORY.name());
         }
 
-        @DisplayName("정상적으로 음용 기록이 삭제된다")
+        @DisplayName("정상적으로 삭제된다")
         @Test
         void success_validData() {
             // given
@@ -437,12 +449,18 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
+            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+                    .withIntakeHistory(intakeHistory)
+                    .build();
+            intakeDetailRepository.save(intakeHistoryDetail);
+
             // when
-            intakeHistoryService.delete(intakeHistory.getId(), member.getId());
+            intakeHistoryService.deleteDetailHistory(intakeHistory.getId(), member.getId());
 
             // then
-            Optional<IntakeHistory> foundIntakeHistory = intakeHistoryRepository.findById(intakeHistory.getId());
-            assertThat(foundIntakeHistory).isNotPresent();
+            Optional<IntakeHistoryDetail> foundIntakeHistoryDetail = intakeDetailRepository.findById(
+                    intakeHistory.getId());
+            assertThat(foundIntakeHistoryDetail).isNotPresent();
         }
 
         @DisplayName("이전 날짜의 기록에 대해 삭제 요청을 하는 경우 예외가 발생한다")
@@ -460,8 +478,13 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
+            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+                    .withIntakeHistory(intakeHistory)
+                    .build();
+            intakeDetailRepository.save(intakeHistoryDetail);
+
             // when & then
-            assertThatThrownBy(() -> intakeHistoryService.delete(intakeHistory.getId(), member.getId()))
+            assertThatThrownBy(() -> intakeHistoryService.deleteDetailHistory(intakeHistory.getId(), member.getId()))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(INVALID_DATE_FOR_DELETE_INTAKE_HISTORY.name());
         }

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -8,7 +8,7 @@ import backend.mulkkam.intake.dto.request.DateRangeRequest;
 import backend.mulkkam.intake.dto.request.IntakeDetailCreateRequest;
 import backend.mulkkam.intake.dto.response.IntakeDetailResponse;
 import backend.mulkkam.intake.dto.response.IntakeHistorySummaryResponse;
-import backend.mulkkam.intake.repository.IntakeDetailRepository;
+import backend.mulkkam.intake.repository.IntakeHistoryDetailRepository;
 import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.domain.vo.MemberNickname;
@@ -50,7 +50,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private IntakeDetailRepository intakeDetailRepository;
+    private IntakeHistoryDetailRepository intakeHistoryDetailRepository;
 
     @DisplayName("음용량을 저장할 때에")
     @Nested
@@ -278,7 +278,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             intakeHistoryRepository.save(historyOfAnotherMember);
             IntakeHistory savedHistoryOfMember = intakeHistoryRepository.save(historyOfMember);
 
-            intakeDetailRepository.saveAll(List.of(detailOfAnotherMember, detailOfMember));
+            intakeHistoryDetailRepository.saveAll(List.of(detailOfAnotherMember, detailOfMember));
 
             // when
             List<IntakeHistorySummaryResponse> actual = intakeHistoryService.readSummaryOfIntakeHistories(
@@ -333,7 +333,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
 
             intakeHistoryRepository.save(intakeHistory);
-            intakeDetailRepository.saveAll(List.of(
+            intakeHistoryDetailRepository.saveAll(List.of(
                     firstIntakeDetail, secondIntakeDetail, thirdIntakeDetail
             ));
 
@@ -392,7 +392,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
-            intakeDetailRepository.save(intakeHistoryDetail);
+            intakeHistoryDetailRepository.save(intakeHistoryDetail);
 
             // when & then
             assertThatThrownBy(
@@ -425,7 +425,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
-            intakeDetailRepository.save(intakeHistoryDetail);
+            intakeHistoryDetailRepository.save(intakeHistoryDetail);
 
             // when & then
             assertThatThrownBy(
@@ -452,13 +452,13 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
-            intakeDetailRepository.save(intakeHistoryDetail);
+            intakeHistoryDetailRepository.save(intakeHistoryDetail);
 
             // when
             intakeHistoryService.deleteDetailHistory(intakeHistory.getId(), member.getId());
 
             // then
-            Optional<IntakeHistoryDetail> foundIntakeHistoryDetail = intakeDetailRepository.findById(
+            Optional<IntakeHistoryDetail> foundIntakeHistoryDetail = intakeHistoryDetailRepository.findById(
                     intakeHistory.getId());
             assertThat(foundIntakeHistoryDetail).isNotPresent();
         }
@@ -481,7 +481,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
             IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
-            intakeDetailRepository.save(intakeHistoryDetail);
+            intakeHistoryDetailRepository.save(intakeHistoryDetail);
 
             // when & then
             assertThatThrownBy(() -> intakeHistoryService.deleteDetailHistory(intakeHistory.getId(), member.getId()))

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceIntegrationTest.java
@@ -13,7 +13,7 @@ import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.domain.vo.MemberNickname;
 import backend.mulkkam.member.repository.MemberRepository;
-import backend.mulkkam.support.IntakeDetailFixtureBuilder;
+import backend.mulkkam.support.IntakeHistoryDetailFixtureBuilder;
 import backend.mulkkam.support.IntakeHistoryFixtureBuilder;
 import backend.mulkkam.support.MemberFixtureBuilder;
 import backend.mulkkam.support.ServiceIntegrationTest;
@@ -262,7 +262,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .date(LocalDate.of(2025, 10, 20))
                     .build();
 
-            IntakeHistoryDetail detailOfAnotherMember = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail detailOfAnotherMember = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(historyOfAnotherMember)
                     .build();
 
@@ -271,7 +271,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .date(LocalDate.of(2025, 10, 20))
                     .build();
 
-            IntakeHistoryDetail detailOfMember = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail detailOfMember = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(historyOfMember)
                     .build();
 
@@ -317,17 +317,17 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .targetIntakeAmount(new Amount(targetAmountOfMember))
                     .build();
 
-            IntakeHistoryDetail firstIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail firstIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
 
-            IntakeHistoryDetail secondIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail secondIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
 
-            IntakeHistoryDetail thirdIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail thirdIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
@@ -389,7 +389,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
-            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail intakeHistoryDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
             intakeHistoryDetailRepository.save(intakeHistoryDetail);
@@ -422,7 +422,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
-            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail intakeHistoryDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
             intakeHistoryDetailRepository.save(intakeHistoryDetail);
@@ -449,7 +449,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
-            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail intakeHistoryDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
             intakeHistoryDetailRepository.save(intakeHistoryDetail);
@@ -478,7 +478,7 @@ class IntakeHistoryServiceIntegrationTest extends ServiceIntegrationTest {
                     .build();
             intakeHistoryRepository.save(intakeHistory);
 
-            IntakeHistoryDetail intakeHistoryDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail intakeHistoryDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .build();
             intakeHistoryDetailRepository.save(intakeHistoryDetail);

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
@@ -8,7 +8,7 @@ import backend.mulkkam.intake.dto.request.DateRangeRequest;
 import backend.mulkkam.intake.dto.request.IntakeDetailCreateRequest;
 import backend.mulkkam.intake.dto.response.IntakeDetailResponse;
 import backend.mulkkam.intake.dto.response.IntakeHistorySummaryResponse;
-import backend.mulkkam.intake.repository.IntakeDetailRepository;
+import backend.mulkkam.intake.repository.IntakeHistoryDetailRepository;
 import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.repository.MemberRepository;
@@ -54,7 +54,7 @@ class IntakeHistoryServiceUnitTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private IntakeDetailRepository intakeDetailRepository;
+    private IntakeHistoryDetailRepository intakeHistoryDetailRepository;
 
     @DisplayName("물의 음용량을 저장할 때에")
     @Nested
@@ -115,7 +115,7 @@ class IntakeHistoryServiceUnitTest {
             assertThatThrownBy(() -> intakeHistoryService.create(intakeDetailCreateRequest, memberId))
                     .isInstanceOf(CommonException.class)
                     .hasMessage(INVALID_AMOUNT.name());
-            verify(intakeDetailRepository, never()).save(any(IntakeHistoryDetail.class));
+            verify(intakeHistoryDetailRepository, never()).save(any(IntakeHistoryDetail.class));
             verify(intakeHistoryRepository, never()).save(any(IntakeHistory.class));
         }
 
@@ -182,7 +182,7 @@ class IntakeHistoryServiceUnitTest {
 
             Collections.shuffle(details);
 
-            given(intakeDetailRepository.findAllByMemberIdAndDateRange(memberId, startDate, endDate))
+            given(intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(memberId, startDate, endDate))
                     .willReturn(details);
 
             // when
@@ -243,7 +243,7 @@ class IntakeHistoryServiceUnitTest {
                     thirdIntakeDetail,
                     fourthIntakeDetail
             ));
-            given(intakeDetailRepository.findAllByMemberIdAndDateRange(memberId, startDate, endDate))
+            given(intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(memberId, startDate, endDate))
                     .willReturn(details);
 
             // when
@@ -319,7 +319,7 @@ class IntakeHistoryServiceUnitTest {
 
             List<IntakeHistoryDetail> details = List.of(firstIntakeDetail, secondIntakeDetail, thirdIntakeDetail);
 
-            given(intakeDetailRepository.findAllByMemberIdAndDateRange(memberId, startDate, endDate))
+            given(intakeHistoryDetailRepository.findAllByMemberIdAndDateRange(memberId, startDate, endDate))
                     .willReturn(details);
 
             // when

--- a/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/service/IntakeHistoryServiceUnitTest.java
@@ -12,7 +12,7 @@ import backend.mulkkam.intake.repository.IntakeHistoryDetailRepository;
 import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.repository.MemberRepository;
-import backend.mulkkam.support.IntakeDetailFixtureBuilder;
+import backend.mulkkam.support.IntakeHistoryDetailFixtureBuilder;
 import backend.mulkkam.support.IntakeHistoryFixtureBuilder;
 import backend.mulkkam.support.MemberFixtureBuilder;
 import java.time.LocalDate;
@@ -162,17 +162,17 @@ class IntakeHistoryServiceUnitTest {
                     .withMember(member)
                     .build();
 
-            IntakeHistoryDetail firstIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail firstIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
 
-            IntakeHistoryDetail secondIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail secondIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
 
-            IntakeHistoryDetail thirdIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail thirdIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
@@ -217,22 +217,22 @@ class IntakeHistoryServiceUnitTest {
                     .withMember(member)
                     .build();
 
-            IntakeHistoryDetail firstIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail firstIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .time(LocalTime.of(10, 0))
                     .build();
 
-            IntakeHistoryDetail secondIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail secondIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .time(LocalTime.of(11, 0))
                     .build();
 
-            IntakeHistoryDetail thirdIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail thirdIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .time(LocalTime.of(15, 0))
                     .build();
 
-            IntakeHistoryDetail fourthIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail fourthIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .time(LocalTime.of(13, 0))
                     .build();
@@ -302,17 +302,17 @@ class IntakeHistoryServiceUnitTest {
                     .withMember(member)
                     .build();
 
-            IntakeHistoryDetail firstIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail firstIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
 
-            IntakeHistoryDetail secondIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail secondIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();
 
-            IntakeHistoryDetail thirdIntakeDetail = IntakeDetailFixtureBuilder
+            IntakeHistoryDetail thirdIntakeDetail = IntakeHistoryDetailFixtureBuilder
                     .withIntakeHistory(intakeHistory)
                     .intakeAmount(new Amount(500))
                     .build();

--- a/backend/src/test/java/backend/mulkkam/support/IntakeHistoryDetailFixtureBuilder.java
+++ b/backend/src/test/java/backend/mulkkam/support/IntakeHistoryDetailFixtureBuilder.java
@@ -5,26 +5,26 @@ import backend.mulkkam.intake.domain.IntakeHistoryDetail;
 import backend.mulkkam.intake.domain.vo.Amount;
 import java.time.LocalTime;
 
-public class IntakeDetailFixtureBuilder {
+public class IntakeHistoryDetailFixtureBuilder {
 
     private final IntakeHistory intakeHistory;
     private LocalTime time = LocalTime.of(10, 0, 0);
     private Amount intakeAmount = new Amount(1_000);
 
-    private IntakeDetailFixtureBuilder(IntakeHistory intakeHistory) {
+    private IntakeHistoryDetailFixtureBuilder(IntakeHistory intakeHistory) {
         this.intakeHistory = intakeHistory;
     }
 
-    public static IntakeDetailFixtureBuilder withIntakeHistory(IntakeHistory intakeHistory) {
-        return new IntakeDetailFixtureBuilder(intakeHistory);
+    public static IntakeHistoryDetailFixtureBuilder withIntakeHistory(IntakeHistory intakeHistory) {
+        return new IntakeHistoryDetailFixtureBuilder(intakeHistory);
     }
 
-    public IntakeDetailFixtureBuilder intakeAmount(Amount intakeAmount) {
+    public IntakeHistoryDetailFixtureBuilder intakeAmount(Amount intakeAmount) {
         this.intakeAmount = intakeAmount;
         return this;
     }
 
-    public IntakeDetailFixtureBuilder time(LocalTime time) {
+    public IntakeHistoryDetailFixtureBuilder time(LocalTime time) {
         this.time = time;
         return this;
     }


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #299 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 기존의 `intake_history` 를 `intake_history_detail` 로 수정함으로서 `intake_history` -> `intake_history_detail` 삭제하도록 수정
