### PR TITLE
[BE][fix]: 금일 현황 반환 로직 스트릭 값 잘못나오던 것을 수정

### DIFF
--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -1,5 +1,10 @@
 package backend.mulkkam.intake.service;
 
+import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_DATE_FOR_DELETE_INTAKE_HISTORY;
+import static backend.mulkkam.common.exception.errorCode.ForbiddenErrorCode.NOT_PERMITTED_FOR_INTAKE_HISTORY;
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY;
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY_DETAIL;
+
 import backend.mulkkam.common.exception.CommonException;
 import backend.mulkkam.intake.domain.CommentOfAchievementRate;
 import backend.mulkkam.intake.domain.IntakeHistory;
@@ -25,11 +30,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_DATE_FOR_DELETE_INTAKE_HISTORY;
-import static backend.mulkkam.common.exception.errorCode.ForbiddenErrorCode.NOT_PERMITTED_FOR_INTAKE_HISTORY;
-import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY;
-import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_INTAKE_HISTORY_DETAIL;
-
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -50,7 +50,7 @@ public class IntakeHistoryService {
                         intakeDateTime.toLocalDate()
                 )
                 .orElseGet(() -> {
-                    int streak = findStreak(member, intakeDetailCreateRequest.dateTime().toLocalDate()) + 1;
+                    int streak = findStreak(member, intakeDetailCreateRequest.dateTime().toLocalDate());
                     IntakeHistory newIntakeHistory = new IntakeHistory(
                             member,
                             intakeDateTime.toLocalDate(),
@@ -159,7 +159,7 @@ public class IntakeHistoryService {
     private int findStreak(Member member, LocalDate todayDate) {
         Optional<IntakeHistory> yesterdayIntakeHistory = intakeHistoryRepository.findByMemberAndHistoryDate(
                 member, todayDate.minusDays(1));
-        return yesterdayIntakeHistory.map(IntakeHistory::getStreak).orElse(0);
+        return yesterdayIntakeHistory.map(intakeHistory -> intakeHistory.getStreak() + 1).orElse(1);
     }
 
     private IntakeHistorySummaryResponse toIntakeHistorySummaryResponse(

--- a/backend/src/main/java/backend/mulkkam/member/dto/response/ProgressInfoResponse.java
+++ b/backend/src/main/java/backend/mulkkam/member/dto/response/ProgressInfoResponse.java
@@ -32,11 +32,12 @@ public record ProgressInfoResponse(
     }
 
     public ProgressInfoResponse(
-            Member member
+            Member member,
+            int streak
     ) {
         this(
                 member.getMemberNickname().value(),
-                0,
+                streak,
                 0.0,
                 member.getTargetAmount().value(),
                 0,

--- a/backend/src/test/java/backend/mulkkam/member/service/MemberServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/service/MemberServiceIntegrationTest.java
@@ -1,5 +1,14 @@
 package backend.mulkkam.member.service;
 
+import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_AMOUNT;
+import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_MEMBER_NICKNAME;
+import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.SAME_AS_BEFORE_NICKNAME;
+import static backend.mulkkam.common.exception.errorCode.ConflictErrorCode.DUPLICATE_MEMBER_NICKNAME;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import backend.mulkkam.auth.domain.OauthAccount;
 import backend.mulkkam.auth.domain.OauthProvider;
 import backend.mulkkam.auth.repository.OauthAccountRepository;
@@ -32,15 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_AMOUNT;
-import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_MEMBER_NICKNAME;
-import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.SAME_AS_BEFORE_NICKNAME;
-import static backend.mulkkam.common.exception.errorCode.ConflictErrorCode.DUPLICATE_MEMBER_NICKNAME;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class MemberServiceIntegrationTest extends ServiceIntegrationTest {
 
@@ -412,7 +412,7 @@ class MemberServiceIntegrationTest extends ServiceIntegrationTest {
             // then
             assertSoftly(softly -> {
                 softly.assertThat(progressInfoResponse.memberNickname()).isEqualTo(nickname);
-                softly.assertThat(progressInfoResponse.streak()).isEqualTo(0);
+                softly.assertThat(progressInfoResponse.streak()).isEqualTo(1);
                 softly.assertThat(progressInfoResponse.achievementRate()).isEqualTo(0);
                 softly.assertThat(progressInfoResponse.targetAmount()).isEqualTo(rawTargetAmount);
                 softly.assertThat(progressInfoResponse.totalAmount()).isEqualTo(0);


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->
스트릭 계산 방식을 수정합니다.

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #378 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->
