### PR TITLE
[AN}[refactor]: [AN][refactor]: 기록 화면 상세 내역 삭제하는 기능 수정

### DIFF
--- a/android/app/src/main/java/com/mulkkam/ui/history/HistoryFragment.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/history/HistoryFragment.kt
@@ -4,6 +4,7 @@ import android.content.res.ColorStateList
 import android.graphics.SweepGradient
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.content.ContextCompat.getDrawable
@@ -148,8 +149,7 @@ class HistoryFragment :
 
         viewModel.deleteSuccess.observe(viewLifecycleOwner) { isSuccess ->
             if (isSuccess) {
-                val currentSelectedDate = viewModel.dailyIntakeHistories.value?.date ?: LocalDate.now()
-                viewModel.loadIntakeHistories(currentSelectedDate)
+                Toast.makeText(requireContext(), "기록이 삭제되었습니다.", Toast.LENGTH_SHORT).show()
 
                 viewModel.onDeleteSuccessObserved()
             }


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #372 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 기존에는 삭제 성공 시 서버에서 데이터를 다시 불러왔으나, 로컬 데이터를 직접 업데이트하도록 변경하여 불필요한 네트워크 요청을 줄였습니다. 또한, 삭제 성공 시 사용자에게 "기록이 삭제되었습니다." 라는 토스트 메시지를 표시하도록 변경했습니다

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 기록 화면 상세 내역 삭제 시 로컬 데이터를 직접 업데이트 하도록 변경
2. 토스트 메세지 표시

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->
