### PR TITLE
Feat/463

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -2,7 +2,7 @@ name: backend-cd.yml
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: ["develop"]
     paths:
       - "backend/**"
 
@@ -69,6 +69,7 @@ jobs:
           echo "LOG_PATH=${{ secrets.LOG_PATH }}" >> ~/mulkkam/.env
           echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> ~/mulkkam/.env
           echo "ACCESS_TOKEN_EXPIRE=${{ secrets.ACCESS_TOKEN_EXPIRE }}" >> ~/mulkkam/.env
+          echo "REFRESH_TOKEN_EXPIRE=${{ secrets.REFRESH_TOKEN_EXPIRE }}" >> ~/mulkkam/.env
           echo "FCM_BASE64_ENCODING_KEY=${{ secrets.FCM_BASE64_ENCODING_KEY }}" >> ~/mulkkam/.env
           echo "FCM_PROJECT_ID=${{ secrets.FCM_PROJECT_ID }}" >> ~/mulkkam/.env
           echo "OPEN_WEATHER_API_KEY=${{ secrets.OPEN_WEATHER_API_KEY }}" >> ~/mulkkam/.env

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -58,5 +58,6 @@ jobs:
           FCM_PROJECT_ID: ${{ secrets.FCM_PROJECT_ID }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           ACCESS_TOKEN_EXPIRE: ${{ secrets.ACCESS_TOKEN_EXPIRE }}
+          REFRESH_TOKEN_EXPIRE: ${{ secrets.REFRESH_TOKEN_EXPIRE }}
         run: SPRING_PROFILES_ACTIVE=ci ./gradlew clean test --stacktrace
         working-directory: ./backend

--- a/backend/src/main/java/backend/mulkkam/auth/domain/AccountRefreshToken.java
+++ b/backend/src/main/java/backend/mulkkam/auth/domain/AccountRefreshToken.java
@@ -1,0 +1,36 @@
+package backend.mulkkam.auth.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class AccountRefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "account_id", nullable = false)
+    @ManyToOne
+    private OauthAccount account;
+
+    private String refreshToken;
+
+    public AccountRefreshToken(OauthAccount account, String refreshToken) {
+        this(null, account, refreshToken);
+    }
+
+    public void reissueToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/backend/src/main/java/backend/mulkkam/auth/service/KakaoAuthService.java
+++ b/backend/src/main/java/backend/mulkkam/auth/service/KakaoAuthService.java
@@ -31,7 +31,7 @@ public class KakaoAuthService {
         OauthAccount oauthAccount = oauthAccountRepository.findByOauthId(oauthId)
                 .orElseGet(() -> oauthAccountRepository.save(new OauthAccount(oauthId, OauthProvider.KAKAO)));
 
-        String token = jwtTokenHandler.createToken(oauthAccount);
+        String token = jwtTokenHandler.createAccessToken(oauthAccount);
         return new OauthLoginResponse(token, oauthAccount.finishedOnboarding());
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -26,7 +26,10 @@ spring:
 security:
   jwt:
     secret-key: ${JWT_SECRET}
-    expire-length: ${ACCESS_TOKEN_EXPIRE}
+    access:
+      expire-length: ${ACCESS_TOKEN_EXPIRE}
+    refresh:
+      expire-length: ${REFRESH_TOKEN_EXPIRE}
 
 fcm:
   base64-encoding-key: ${FCM_BASE64_ENCODING_KEY}

--- a/backend/src/test/java/backend/mulkkam/auth/infrastructure/OauthJwtTokenHandlerTest.java
+++ b/backend/src/test/java/backend/mulkkam/auth/infrastructure/OauthJwtTokenHandlerTest.java
@@ -32,7 +32,7 @@ class OauthJwtTokenHandlerTest extends ServiceIntegrationTest {
             oauthAccountRepository.save(oauthAccount);
 
             // when
-            String token = oauthJwtTokenHandler.createToken(oauthAccount);
+            String token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
             Long actual = oauthJwtTokenHandler.getSubject(token);
 
             // then
@@ -50,7 +50,7 @@ class OauthJwtTokenHandlerTest extends ServiceIntegrationTest {
             // given
             OauthAccount oauthAccount = new OauthAccount("testId", OauthProvider.KAKAO);
             oauthAccountRepository.save(oauthAccount);
-            String token = oauthJwtTokenHandler.createToken(oauthAccount);
+            String token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
 
             // when
             Long actual = oauthJwtTokenHandler.getSubject(token);

--- a/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
@@ -173,7 +173,7 @@ class MemberControllerTest {
             OauthAccount oauthAccount = new OauthAccount("temp", OauthProvider.KAKAO);
             oauthAccountRepository.save(oauthAccount);
 
-            String token = oauthJwtTokenHandler.createToken(oauthAccount);
+            String token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
 
             CreateMemberRequest createMemberRequest = new CreateMemberRequest(
                     "히로",
@@ -205,7 +205,7 @@ class MemberControllerTest {
             OauthAccount oauthAccount = new OauthAccount("temp", OauthProvider.KAKAO);
             oauthAccountRepository.save(oauthAccount);
 
-            String token = oauthJwtTokenHandler.createToken(oauthAccount);
+            String token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
 
             CreateMemberRequest createMemberRequest = new CreateMemberRequest(
                     "히로",
@@ -247,7 +247,7 @@ class MemberControllerTest {
             OauthAccount oauthAccount = new OauthAccount("temp", OauthProvider.KAKAO);
             oauthAccountRepository.save(oauthAccount);
 
-            String token = oauthJwtTokenHandler.createToken(oauthAccount);
+            String token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
 
             // when
             OnboardingStatusResponse response = RestAssured.given().log().all()

--- a/backend/src/test/resources/application-ci.yml
+++ b/backend/src/test/resources/application-ci.yml
@@ -24,7 +24,10 @@ fcm:
 security:
   jwt:
     secret-key: ${JWT_SECRET}
-    expire-length: ${ACCESS_TOKEN_EXPIRE}
+    access:
+      expire-length: ${ACCESS_TOKEN_EXPIRE}
+    refresh:
+      expire-length: ${REFRESH_TOKEN_EXPIRE}
 
 open-weather:
   api:


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #463

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- `AccountRefreshToken` 엔티티 추가 - 로그인 유저의 리프레시 토큰 값 관리
- `OauthJwtTokenHandler` - 리프레시 토큰 생성 로직 추가

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 엔티티 추가
> 백엔드 회의 및 안드로이드 회의를 거쳐서 `device` 식별 관련해서 이야기 나눠야 함
> - 현재는 `device id`로 리프레시 토큰을 식별하지 않으므로, _"전체 기기 로그아웃"_ 만 가능할뿐 _"특정 기기 로그아웃"_ 이 불가능한 상태임

