### PR TITLE
[BE][feat]: FCM 의 예외 처리

### DIFF
--- a/backend/src/main/java/backend/mulkkam/common/exception/AlarmException.java
+++ b/backend/src/main/java/backend/mulkkam/common/exception/AlarmException.java
@@ -1,0 +1,18 @@
+package backend.mulkkam.common.exception;
+
+import backend.mulkkam.common.exception.errorCode.ErrorCode;
+import backend.mulkkam.common.exception.errorCode.FirebaseErrorCode;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+
+public class AlarmException extends CommonException {
+
+    public AlarmException(FirebaseMessagingException firebaseMessagingException) {
+        super(getErrorCode(firebaseMessagingException));
+    }
+
+    private static ErrorCode getErrorCode(FirebaseMessagingException firebaseMessagingException) {
+        MessagingErrorCode messagingErrorCode = firebaseMessagingException.getMessagingErrorCode();
+        return FirebaseErrorCode.findByName(messagingErrorCode.name());
+    }
+}

--- a/backend/src/main/java/backend/mulkkam/common/exception/errorCode/FirebaseErrorCode.java
+++ b/backend/src/main/java/backend/mulkkam/common/exception/errorCode/FirebaseErrorCode.java
@@ -1,0 +1,39 @@
+package backend.mulkkam.common.exception.errorCode;
+
+import java.util.Arrays;
+import org.springframework.http.HttpStatus;
+
+public enum FirebaseErrorCode implements ErrorCode {
+
+    THIRD_PARTY_AUTH_ERROR(HttpStatus.UNAUTHORIZED),
+
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST),
+
+    INTERNAL(HttpStatus.INTERNAL_SERVER_ERROR),
+
+    QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS),
+
+    SENDER_ID_MISMATCH(HttpStatus.FORBIDDEN),
+
+    UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE),
+
+    UNREGISTERED(HttpStatus.GONE);
+
+    private final HttpStatus httpStatus;
+
+    FirebaseErrorCode(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    public static FirebaseErrorCode findByName(String name) {
+        return Arrays.stream(FirebaseErrorCode.values())
+                .filter(firebaseErrorCode -> firebaseErrorCode.name().equals(name))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid FirebaseErrorCode name: " + name));
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+}

--- a/backend/src/main/java/backend/mulkkam/notification/service/NotificationService.java
+++ b/backend/src/main/java/backend/mulkkam/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import static backend.mulkkam.common.exception.errorCode.BadGateErrorCode.SEND_M
 import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.INVALID_PAGE_SIZE_RANGE;
 
 import backend.mulkkam.averageTemperature.dto.CreateTokenNotificationRequest;
+import backend.mulkkam.common.exception.AlarmException;
 import backend.mulkkam.common.exception.CommonException;
 import backend.mulkkam.common.infrastructure.fcm.dto.request.SendMessageByFcmTokenRequest;
 import backend.mulkkam.common.infrastructure.fcm.dto.request.SendMessageByFcmTopicRequest;
@@ -89,13 +90,14 @@ public class NotificationService {
         try {
             sendNotificationByMember(createTokenNotificationRequest, devicesByMember);
         } catch (FirebaseMessagingException e) {
-            throw new CommonException(SEND_MESSAGE_FAILED);
+            throw new AlarmException(e);
         }
     }
 
-    private void sendNotificationByMember(CreateTokenNotificationRequest createTokenNotificationRequest,
-                                          List<Device> devicesByMember)
-            throws FirebaseMessagingException {
+    private void sendNotificationByMember(
+            CreateTokenNotificationRequest createTokenNotificationRequest,
+            List<Device> devicesByMember
+    ) throws FirebaseMessagingException {
         for (Device device : devicesByMember) {
             SendMessageByFcmTokenRequest sendMessageByFcmTokenRequest = createTokenNotificationRequest.toSendMessageByFcmTokenRequest(
                     device.getToken());

--- a/backend/src/test/java/backend/mulkkam/notification/service/NotificationServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/notification/service/NotificationServiceIntegrationTest.java
@@ -38,7 +38,7 @@ class NotificationServiceIntegrationTest extends ServiceIntegrationTest {
     private NotificationRepository notificationRepository;
 
     private Member savedMember;
-    private Long savedMemberId;
+
     @Autowired
     private MemberRepository memberRepository;
 
@@ -46,7 +46,6 @@ class NotificationServiceIntegrationTest extends ServiceIntegrationTest {
     void setUp() {
         Member member = MemberFixtureBuilder.builder().build();
         savedMember = memberRepository.save(member);
-        savedMemberId = savedMember.getId();
     }
 
     @DisplayName("알림 조회 기능을 사용할 때")


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #412 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
기존에 모든 FCM 예외를 SEND_MESSAGE_FAILED로 일괄 처리하던 로직을, 
FCM이 제공하는 기본 errorCode를 기반으로 세분화된 예외 처리로 변경했습니다~~
테스트 코드는 아직 작성하지 않았으며, 
알림 모듈과 연결되어 작업량이 커질 것으로 예상되어 별도로 분리하여 진행할 예정입니다!

예외 처리 방식 정도만 봐주시면 될 것 같아요!
### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->
