### PR TITLE
[BE][feat]: 멤버 알림 세팅 조회 로직

### DIFF
--- a/backend/src/main/java/backend/mulkkam/member/controller/MemberController.java
+++ b/backend/src/main/java/backend/mulkkam/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import backend.mulkkam.member.dto.request.ModifyIsNightNotificationAgreedRequest
 import backend.mulkkam.member.dto.request.PhysicalAttributesModifyRequest;
 import backend.mulkkam.member.dto.response.MemberNicknameResponse;
 import backend.mulkkam.member.dto.response.MemberResponse;
+import backend.mulkkam.member.dto.response.NotificationSettingsResponse;
 import backend.mulkkam.member.dto.response.ProgressInfoResponse;
 import backend.mulkkam.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -171,7 +172,7 @@ public class MemberController {
 
     @Operation(summary = "사용자 야간 알림 수신 정보 수정", description = "야간 알림 수신 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "야간 알림 반영 성공")
-    @PatchMapping("/notification/night")
+    @PatchMapping("/notifications/night")
     public ResponseEntity<Void> modifyIsNightNotificationAgreed(
             @Parameter(hidden = true)
             Member member,
@@ -184,7 +185,7 @@ public class MemberController {
 
     @Operation(summary = "사용자 마케팅 알림 수신 정보 수정", description = "마케팅 알림 수신 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "마케팅 알림 반영 성공")
-    @PatchMapping("/notification/marketing")
+    @PatchMapping("/notifications/marketing")
     public ResponseEntity<Void> modifyIsMarketingNotificationAgreed(
             @Parameter(hidden = true)
             Member member,
@@ -193,6 +194,17 @@ public class MemberController {
     ) {
         memberService.modifyIsMarketingNotificationAgreed(member, modifyIsMarketingNotificationAgreed);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "사용자 알림 수신 정보 조회", description = "야간/마케팅 알림 수신 여부를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "알림 수신 여부 조회 성공")
+    @GetMapping("/notifications/settings")
+    public ResponseEntity<NotificationSettingsResponse> getNotificationSettings(
+            @Parameter(hidden = true)
+            Member member
+    ) {
+        NotificationSettingsResponse response = memberService.getNotificationSettings(member);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "사용자 탈퇴", description = "회원을 탈퇴합니다")

--- a/backend/src/main/java/backend/mulkkam/member/controller/MemberController.java
+++ b/backend/src/main/java/backend/mulkkam/member/controller/MemberController.java
@@ -203,8 +203,8 @@ public class MemberController {
             @Parameter(hidden = true)
             Member member
     ) {
-        NotificationSettingsResponse response = memberService.getNotificationSettings(member);
-        return ResponseEntity.ok(response);
+        NotificationSettingsResponse notificationSettingsResponse = memberService.getNotificationSettings(member);
+        return ResponseEntity.ok(notificationSettingsResponse);
     }
 
     @Operation(summary = "사용자 탈퇴", description = "회원을 탈퇴합니다")

--- a/backend/src/main/java/backend/mulkkam/member/dto/response/NotificationSettingsResponse.java
+++ b/backend/src/main/java/backend/mulkkam/member/dto/response/NotificationSettingsResponse.java
@@ -1,0 +1,13 @@
+package backend.mulkkam.member.dto.response;
+
+import backend.mulkkam.member.domain.Member;
+
+public record NotificationSettingsResponse(
+        boolean isNightNotificationAgreed,
+        boolean isMarketingNotificationAgreed
+) {
+
+    public NotificationSettingsResponse(Member member) {
+        this(member.isNightNotificationAgreed(), member.isMarketingNotificationAgreed());
+    }
+}

--- a/backend/src/main/java/backend/mulkkam/member/dto/response/NotificationSettingsResponse.java
+++ b/backend/src/main/java/backend/mulkkam/member/dto/response/NotificationSettingsResponse.java
@@ -1,9 +1,14 @@
 package backend.mulkkam.member.dto.response;
 
 import backend.mulkkam.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "회원 알림 수신 여부 응답")
 public record NotificationSettingsResponse(
+        @Schema(description = "야간 알림", example = "true")
         boolean isNightNotificationAgreed,
+
+        @Schema(description = "마케팅 알림", example = "true")
         boolean isMarketingNotificationAgreed
 ) {
 

--- a/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
+++ b/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
@@ -28,6 +28,7 @@ import backend.mulkkam.member.dto.request.ModifyIsNightNotificationAgreedRequest
 import backend.mulkkam.member.dto.request.PhysicalAttributesModifyRequest;
 import backend.mulkkam.member.dto.response.MemberNicknameResponse;
 import backend.mulkkam.member.dto.response.MemberResponse;
+import backend.mulkkam.member.dto.response.NotificationSettingsResponse;
 import backend.mulkkam.member.dto.response.ProgressInfoResponse;
 import backend.mulkkam.member.repository.MemberRepository;
 import backend.mulkkam.notification.repository.NotificationRepository;
@@ -184,6 +185,10 @@ public class MemberService {
         notificationRepository.deleteByMember(member);
 
         memberRepository.delete(member);
+    }
+
+    public NotificationSettingsResponse getNotificationSettings(Member member) {
+        return new NotificationSettingsResponse(member);
     }
 
     private int calculateTotalIntakeAmount(List<IntakeHistoryDetail> intakeHistoryDetails) {

--- a/backend/src/test/java/backend/mulkkam/intake/controller/IntakeTargetAmountControllerTest.java
+++ b/backend/src/test/java/backend/mulkkam/intake/controller/IntakeTargetAmountControllerTest.java
@@ -86,7 +86,7 @@ class IntakeAmountControllerTest {
         token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
     }
 
-    @DisplayName("목표 음용량을 추천받는다")
+    @DisplayName("목표 음용량을 추천받을 때에")
     @Nested
     class GetRecommended {
 
@@ -353,7 +353,7 @@ class IntakeAmountControllerTest {
         }
     }
 
-    @DisplayName("멤버의 목표 음용량을 얻을 때에")
+    @DisplayName("멤버의 목표 음용량을 조회할 때에")
     @Nested
     class GetTarget {
 

--- a/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
@@ -1,5 +1,14 @@
 package backend.mulkkam.member.controller;
 
+import static backend.mulkkam.auth.domain.OauthProvider.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import backend.mulkkam.auth.domain.AccountRefreshToken;
 import backend.mulkkam.auth.domain.OauthAccount;
 import backend.mulkkam.auth.domain.OauthProvider;
@@ -15,6 +24,7 @@ import backend.mulkkam.intake.repository.IntakeHistoryRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.dto.request.ModifyIsMarketingNotificationAgreedRequest;
 import backend.mulkkam.member.dto.request.ModifyIsNightNotificationAgreedRequest;
+import backend.mulkkam.member.dto.response.NotificationSettingsResponse;
 import backend.mulkkam.member.repository.MemberRepository;
 import backend.mulkkam.support.AccountRefreshTokenFixtureBuilder;
 import backend.mulkkam.support.CupFixtureBuilder;
@@ -32,14 +42,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static backend.mulkkam.auth.domain.OauthProvider.KAKAO;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -106,7 +108,7 @@ class MemberControllerTest {
                     false);
 
             // when
-            mockMvc.perform(patch("/members/notification/night")
+            mockMvc.perform(patch("/members/notifications/night")
                             .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(modifyIsNightNotificationAgreedRequest)))
@@ -128,7 +130,7 @@ class MemberControllerTest {
                     false);
 
             // when
-            mockMvc.perform(patch("/members/notification/marketing")
+            mockMvc.perform(patch("/members/notifications/marketing")
                             .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(modifyIsMarketingNotificationAgreedRequest)))
@@ -140,6 +142,28 @@ class MemberControllerTest {
             assertSoftly(softly ->
                     softly.assertThat(foundMember.isMarketingNotificationAgreed()).isFalse()
             );
+        }
+    }
+
+    @DisplayName("멤버의 정보를 조회할 때에")
+    @Nested
+    class Get {
+
+        @DisplayName("야간 알림과 마케팅 수신 동의 세팅을 가져온다.")
+        @Test
+        void success_whenModifyIsNightNotificationAgreed() throws Exception {
+            // when
+            String json = mockMvc.perform(get("/members/notifications/settings")
+                            .header(org.springframework.http.HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+
+            NotificationSettingsResponse actual = objectMapper.readValue(json, NotificationSettingsResponse.class);
+
+            assertSoftly(softly -> {
+                softly.assertThat(actual.isNightNotificationAgreed()).isTrue();
+                softly.assertThat(actual.isMarketingNotificationAgreed()).isTrue();
+            });
         }
     }
 

--- a/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
@@ -160,6 +160,7 @@ class MemberControllerTest {
 
             NotificationSettingsResponse actual = objectMapper.readValue(json, NotificationSettingsResponse.class);
 
+            //then
             assertSoftly(softly -> {
                 softly.assertThat(actual.isNightNotificationAgreed()).isTrue();
                 softly.assertThat(actual.isMarketingNotificationAgreed()).isTrue();


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->
 마케팅 및 야간 알림 수신을 조회 로직 구현을 구현합니다.

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #527 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->
