### PR TITLE
[BE][fix]: 리졸버에서 커스텀 예외 던지도록 수정

### DIFF
--- a/backend/src/main/java/backend/mulkkam/common/resolver/MemberResolver.java
+++ b/backend/src/main/java/backend/mulkkam/common/resolver/MemberResolver.java
@@ -2,6 +2,7 @@ package backend.mulkkam.common.resolver;
 
 import backend.mulkkam.auth.domain.OauthAccount;
 import backend.mulkkam.auth.repository.OauthAccountRepository;
+import backend.mulkkam.common.exception.CommonException;
 import backend.mulkkam.member.domain.Member;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_MEMBER;
 
 @Component
 @RequiredArgsConstructor
@@ -34,7 +37,7 @@ public class MemberResolver implements HandlerMethodArgumentResolver {
         Long accountId = (Long) request.getAttribute("subject");
 
         OauthAccount oauthAccount = oauthAccountRepository.findByIdWithMember(accountId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다"));
+                .orElseThrow(() -> new CommonException(NOT_FOUND_MEMBER));
 
         return oauthAccount.getMember();
     }

--- a/backend/src/main/java/backend/mulkkam/common/resolver/OauthAccountResolver.java
+++ b/backend/src/main/java/backend/mulkkam/common/resolver/OauthAccountResolver.java
@@ -2,6 +2,7 @@ package backend.mulkkam.common.resolver;
 
 import backend.mulkkam.auth.domain.OauthAccount;
 import backend.mulkkam.auth.repository.OauthAccountRepository;
+import backend.mulkkam.common.exception.CommonException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_MEMBER;
 
 @Component
 @RequiredArgsConstructor
@@ -32,8 +35,7 @@ public class OauthAccountResolver implements HandlerMethodArgumentResolver {
 
         Long accountId = (Long) request.getAttribute("subject");
 
-        // TODO: 추후 에러 코드로 반영
         return oauthAccountRepository.findById(accountId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다"));
+                .orElseThrow(() -> new CommonException(NOT_FOUND_MEMBER));
     }
 }


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 문제상황

```txt
ERROR [SERVER_ERROR] code=INTER_SERVER_ERROR_CODE(500 INTERNAL_SERVER_ERROR IllegalArgumentException), message=존재하지 않는 회원입니다
```
> 리졸버에서 멤버 조회에 실패한 경우 500 에러가 반환되는 문제

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 커스텀 예외로 변경
