### PR TITLE
[BE][refactor] 리졸버 및 서비스에서 중복으로 레파지토리 접근하는 로직 개선

### DIFF
--- a/backend/src/main/java/backend/mulkkam/auth/infrastructure/OauthJwtTokenHandler.java
+++ b/backend/src/main/java/backend/mulkkam/auth/infrastructure/OauthJwtTokenHandler.java
@@ -35,40 +35,7 @@ public class OauthJwtTokenHandler {
                 .build();
     }
 
-    public String createAccessToken(OauthAccount account) {
-        Claims claims = generateClaims(account);
-
-        Date now = new Date();
-        Date validity = new Date(now.getTime() + accessExpireInMilliseconds);
-        return Jwts.builder()
-                .claims(claims)
-                .issuedAt(now)
-                .expiration(validity)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .compact();
-    }
-
-    public String createRefreshToken(OauthAccount account) {
-        Claims claims = generateClaims(account);
-
-        Date now = new Date();
-        Date validity = new Date(now.getTime() + refreshExpireInMilliseconds);
-        return Jwts.builder()
-                .claims(claims)
-                .issuedAt(now)
-                .expiration(validity)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .compact();
-    }
-
-    private Claims generateClaims(OauthAccount account) {
-        return Jwts.claims()
-                .subject(account.getId().toString())
-                .id(UUID.randomUUID().toString())
-                .build();
-    }
-
-    public Long getSubject(String token) throws InvalidTokenException {
+    public Long getAccountId(String token) throws InvalidTokenException {
         try {
             Claims claims = getClaims(token);
             return Long.parseLong(claims.getSubject());
@@ -83,5 +50,37 @@ public class OauthJwtTokenHandler {
         } catch (JwtException | IllegalArgumentException e) {
             throw new InvalidTokenException();
         }
+    }
+
+    public String createAccessToken(OauthAccount account) {
+        Claims claims = generateClaims(account);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessExpireInMilliseconds);
+        return getCompactedJwt(claims, now, validity);
+    }
+
+    public String createRefreshToken(OauthAccount account) {
+        Claims claims = generateClaims(account);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshExpireInMilliseconds);
+        return getCompactedJwt(claims, now, validity);
+    }
+
+    private Claims generateClaims(OauthAccount account) {
+        return Jwts.claims()
+                .subject(account.getId().toString())
+                .id(UUID.randomUUID().toString())
+                .build();
+    }
+
+    private String getCompactedJwt(Claims claims, Date now, Date validity) {
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
     }
 }

--- a/backend/src/main/java/backend/mulkkam/auth/service/AuthTokenService.java
+++ b/backend/src/main/java/backend/mulkkam/auth/service/AuthTokenService.java
@@ -54,7 +54,7 @@ public class AuthTokenService {
 
     private Long getAccountId(String refreshToken) {
         try {
-            return oauthJwtTokenHandler.getSubject(refreshToken);
+            return oauthJwtTokenHandler.getAccountId(refreshToken);
         } catch (InvalidTokenException e) {
             throw new CommonException(REFRESH_TOKEN_IS_EXPIRED);
         }

--- a/backend/src/main/java/backend/mulkkam/common/exception/errorCode/NotFoundErrorCode.java
+++ b/backend/src/main/java/backend/mulkkam/common/exception/errorCode/NotFoundErrorCode.java
@@ -12,7 +12,7 @@ public enum NotFoundErrorCode implements ErrorCode {
     NOT_FOUND_TARGET_AMOUNT_SNAPSHOT,
     NOT_FOUND_AVERAGE_TEMPERATURE,
     NOT_FOUND_INTAKE_HISTORY_DETAIL,
-    NOT_FOUND_OAUTH_ACCOUNT_FOR_MEMBER;
+    NOT_FOUND_OAUTH_ACCOUNT;
 
     private static final HttpStatus status = HttpStatus.NOT_FOUND;
 

--- a/backend/src/main/java/backend/mulkkam/common/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/backend/mulkkam/common/filter/JwtAuthenticationFilter.java
@@ -43,7 +43,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String token = authenticationHeaderHandler.extractToken(request);
             Long accountId = oauthJwtTokenHandler.getAccountId(token);
+            Long memberId = oauthJwtTokenHandler.getMemberId(token);
             request.setAttribute("account_id", accountId);
+            request.setAttribute("member_id", memberId);
             filterChain.doFilter(request, response);
         } catch (InvalidTokenException e) {
             request.setAttribute(RequestDispatcher.ERROR_REQUEST_URI, request.getRequestURI());

--- a/backend/src/main/java/backend/mulkkam/common/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/backend/mulkkam/common/filter/JwtAuthenticationFilter.java
@@ -42,9 +42,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         try {
             String token = authenticationHeaderHandler.extractToken(request);
-            Long subject = oauthJwtTokenHandler.getSubject(token);
-            request.setAttribute("subject", subject);
-            request.setAttribute("account_id", subject);
+            Long accountId = oauthJwtTokenHandler.getAccountId(token);
+            request.setAttribute("account_id", accountId);
             filterChain.doFilter(request, response);
         } catch (InvalidTokenException e) {
             request.setAttribute(RequestDispatcher.ERROR_REQUEST_URI, request.getRequestURI());

--- a/backend/src/main/java/backend/mulkkam/common/resolver/MemberResolver.java
+++ b/backend/src/main/java/backend/mulkkam/common/resolver/MemberResolver.java
@@ -2,8 +2,6 @@ package backend.mulkkam.common.resolver;
 
 import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_MEMBER;
 
-import backend.mulkkam.auth.domain.OauthAccount;
-import backend.mulkkam.auth.repository.OauthAccountRepository;
 import backend.mulkkam.common.dto.MemberDetails;
 import backend.mulkkam.common.exception.CommonException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,8 +17,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class MemberResolver implements HandlerMethodArgumentResolver {
 
-    private final OauthAccountRepository oauthAccountRepository;
-
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.getParameterType().equals(MemberDetails.class);
@@ -35,10 +31,12 @@ public class MemberResolver implements HandlerMethodArgumentResolver {
     ) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
-        Long accountId = (Long) request.getAttribute("account_id");
-        OauthAccount account = oauthAccountRepository.findByIdWithMember(accountId)
-                .orElseThrow(() -> new CommonException(NOT_FOUND_MEMBER));
+        Long memberId = (Long) request.getAttribute("member_id");
 
-        return new MemberDetails(account.getMember());
+        if (memberId == null) {
+            throw new CommonException(NOT_FOUND_MEMBER);
+        }
+
+        return new MemberDetails(memberId);
     }
 }

--- a/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
+++ b/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
@@ -3,7 +3,7 @@ package backend.mulkkam.member.service;
 import static backend.mulkkam.common.exception.errorCode.BadRequestErrorCode.SAME_AS_BEFORE_NICKNAME;
 import static backend.mulkkam.common.exception.errorCode.ConflictErrorCode.DUPLICATE_MEMBER_NICKNAME;
 import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_MEMBER;
-import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_OAUTH_ACCOUNT_FOR_MEMBER;
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_OAUTH_ACCOUNT;
 
 import backend.mulkkam.auth.domain.OauthAccount;
 import backend.mulkkam.auth.repository.AccountRefreshTokenRepository;
@@ -225,6 +225,6 @@ public class MemberService {
 
     private OauthAccount getOauthAccount(OauthAccountDetails accountDetails) {
         return oauthAccountRepository.findById(accountDetails.id())
-                .orElseThrow(() -> new CommonException(NOT_FOUND_OAUTH_ACCOUNT_FOR_MEMBER));
+                .orElseThrow(() -> new CommonException(NOT_FOUND_OAUTH_ACCOUNT));
     }
 }

--- a/backend/src/test/java/backend/mulkkam/auth/infrastructure/OauthJwtTokenHandlerTest.java
+++ b/backend/src/test/java/backend/mulkkam/auth/infrastructure/OauthJwtTokenHandlerTest.java
@@ -34,7 +34,7 @@ class OauthJwtTokenHandlerTest extends ServiceIntegrationTest {
 
             // when
             String token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
-            Long actual = oauthJwtTokenHandler.getSubject(token);
+            Long actual = oauthJwtTokenHandler.getAccountId(token);
 
             // then
             assertThat(actual).isEqualTo(oauthAccount.getId());
@@ -54,7 +54,7 @@ class OauthJwtTokenHandlerTest extends ServiceIntegrationTest {
             String token = oauthJwtTokenHandler.createAccessToken(oauthAccount);
 
             // when
-            Long actual = oauthJwtTokenHandler.getSubject(token);
+            Long actual = oauthJwtTokenHandler.getAccountId(token);
 
             // then
             assertThat(actual).isEqualTo(oauthAccount.getId());
@@ -67,7 +67,7 @@ class OauthJwtTokenHandlerTest extends ServiceIntegrationTest {
             String invalidToken = "invalidToken";
 
             // when & then
-            assertThatThrownBy(() -> oauthJwtTokenHandler.getSubject(invalidToken))
+            assertThatThrownBy(() -> oauthJwtTokenHandler.getAccountId(invalidToken))
                     .isInstanceOf(InvalidTokenException.class);
         }
     }

--- a/backend/src/test/java/backend/mulkkam/common/resolver/MemberResolverTest.java
+++ b/backend/src/test/java/backend/mulkkam/common/resolver/MemberResolverTest.java
@@ -1,25 +1,18 @@
 package backend.mulkkam.common.resolver;
 
+import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import backend.mulkkam.auth.domain.OauthAccount;
-import backend.mulkkam.auth.domain.OauthProvider;
-import backend.mulkkam.auth.repository.OauthAccountRepository;
 import backend.mulkkam.common.dto.MemberDetails;
-import backend.mulkkam.member.domain.Member;
-import backend.mulkkam.member.domain.vo.Gender;
-import backend.mulkkam.member.domain.vo.MemberNickname;
-import backend.mulkkam.member.domain.vo.PhysicalAttributes;
-import backend.mulkkam.member.domain.vo.TargetAmount;
+import backend.mulkkam.common.exception.CommonException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -28,16 +21,11 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import java.util.Optional;
-
 @ExtendWith(MockitoExtension.class)
 class MemberResolverTest {
 
-    @Mock
-    OauthAccountRepository oauthAccountRepository;
-
     @InjectMocks
-    MemberResolver memberResolver;
+    private MemberResolver memberResolver;
 
     @DisplayName("resolveArgument 를 할 때")
     @Nested
@@ -45,27 +33,13 @@ class MemberResolverTest {
 
         @DisplayName("토큰을 추출해 성공적으로 Member 를 반환한다")
         @Test
-        void success_validToken() throws Exception {
+        void success_validToken() {
             // given
             String token = "test-token";
-            long accountId = 1L;
             long memberId = 1L;
 
-            Member member = new Member(
-                    memberId,
-                    new MemberNickname("히로"),
-                    new PhysicalAttributes(Gender.FEMALE, 70.0),
-                    new TargetAmount(1_000),
-                    true,
-                    false
-            );
-
-            OauthAccount account = new OauthAccount(member, "kakao-id", OauthProvider.KAKAO);
-
-            when(oauthAccountRepository.findByIdWithMember(accountId)).thenReturn(Optional.of(account));
-
             MockHttpServletRequest servletRequest = new MockHttpServletRequest();
-            servletRequest.setAttribute("account_id", accountId);
+            servletRequest.setAttribute("member_id", memberId);
             servletRequest.addHeader("Authorization", "Bearer " + token);
             NativeWebRequest webRequest = new ServletWebRequest(servletRequest);
 
@@ -82,6 +56,27 @@ class MemberResolverTest {
                 assertThat(result).isInstanceOf(MemberDetails.class);
                 assertThat(result.id()).isEqualTo(memberId);
             });
+        }
+
+        @DisplayName("토큰을 추출해 성공적으로 Member 를 반환한다")
+        @Test
+        void error_didNotOnboarded() {
+            // given
+            String token = "test-token";
+
+            MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+            servletRequest.addHeader("Authorization", "Bearer " + token);
+            NativeWebRequest webRequest = new ServletWebRequest(servletRequest);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                memberResolver.resolveArgument(
+                        mock(MethodParameter.class),
+                        mock(ModelAndViewContainer.class),
+                        webRequest,
+                        mock(WebDataBinderFactory.class)
+                );
+            }).isInstanceOf(CommonException.class).hasMessage(NOT_FOUND_MEMBER.name());
         }
     }
 }


### PR DESCRIPTION

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
> 기존 코드에서는 멤버 요청에 대해 `리졸버`에서도 repository를 조회하고, `서비스`에서도 repository를 조회함
- 리졸버에서는 단순히 attribute를 전달하도록 변경
- repository 접근은 서비스에서만

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. JWT 토큰 claim에 `memberId` 값 추가
2. `MemberResolver`에서 `OauthAccountRepository` 의존성 제거
