### PR TITLE
[AN][feat]: 기록 화면 이모지 출력 및 액체 타입에 따른 색깔 변경

### DIFF
--- a/android/app/src/main/java/com/mulkkam/data/remote/model/response/intake/IntakeHistoryResponse.kt
+++ b/android/app/src/main/java/com/mulkkam/data/remote/model/response/intake/IntakeHistoryResponse.kt
@@ -1,6 +1,7 @@
 package com.mulkkam.data.remote.model.response.intake
 
 import com.mulkkam.domain.model.intake.IntakeHistory
+import com.mulkkam.domain.model.intake.IntakeType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.LocalTime
@@ -14,6 +15,10 @@ data class IntakeHistoryResponse(
     val dateTime: String,
     @SerialName("intakeAmount")
     val intakeAmount: Int,
+    @SerialName("intakeType")
+    val intakeType: String,
+    @SerialName("cupEmojiUrl")
+    val cupEmojiUrl: String,
 )
 
 fun IntakeHistoryResponse.toDomain() =
@@ -21,4 +26,6 @@ fun IntakeHistoryResponse.toDomain() =
         id = id,
         dateTime = LocalTime.parse(this.dateTime, DateTimeFormatter.ofPattern("HH:mm:ss")),
         intakeAmount = intakeAmount,
+        intakeType = IntakeType.from(intakeType),
+        cupEmojiUrl = cupEmojiUrl,
     )

--- a/android/app/src/main/java/com/mulkkam/domain/model/intake/IntakeHistory.kt
+++ b/android/app/src/main/java/com/mulkkam/domain/model/intake/IntakeHistory.kt
@@ -6,4 +6,6 @@ data class IntakeHistory(
     val id: Int,
     val dateTime: LocalTime,
     val intakeAmount: Int,
+    val intakeType: IntakeType,
+    val cupEmojiUrl: String,
 )

--- a/android/app/src/main/java/com/mulkkam/ui/history/adapter/HistoryViewHolder.kt
+++ b/android/app/src/main/java/com/mulkkam/ui/history/adapter/HistoryViewHolder.kt
@@ -2,10 +2,12 @@ package com.mulkkam.ui.history.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.graphics.toColorInt
 import androidx.recyclerview.widget.RecyclerView
 import com.mulkkam.R
 import com.mulkkam.databinding.ItemIntakeHistoryBinding
 import com.mulkkam.domain.model.intake.IntakeHistory
+import com.mulkkam.ui.util.extensions.loadUrl
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -39,6 +41,9 @@ class HistoryViewHolder(
                     R.string.history_intake_amount,
                     intakeHistory.intakeAmount,
                 )
+            tvIntakeAmount.setTextColor(intakeHistory.intakeType.toColorHex().toColorInt())
+
+            ivCupIcon.loadUrl(intakeHistory.cupEmojiUrl)
         }
     }
 

--- a/android/app/src/main/res/layout/item_intake_history.xml
+++ b/android/app/src/main/res/layout/item_intake_history.xml
@@ -5,17 +5,30 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/selector_history_item_press"
-    android:clickable="true"
-    android:paddingVertical="14dp">
+    android:clickable="true">
+
+    <ImageView
+        android:id="@+id/iv_cup_icon"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="6dp"
+        android:layout_marginStart="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/img_history_character" />
 
     <TextView
         android:id="@+id/tv_intake_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="36dp"
+        android:layout_marginVertical="14dp"
+        android:layout_marginStart="12dp"
         android:gravity="center"
         android:textAppearance="@style/title2"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iv_cup_icon"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="오후 12시 1분" />
 
@@ -23,9 +36,11 @@
         android:id="@+id/tv_intake_amount"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginVertical="14dp"
         android:layout_marginEnd="36dp"
         android:gravity="center"
         android:textAppearance="@style/title2"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="1,000ml" />

--- a/android/app/src/test/java/com/mulkkam/ui/fixture/HistoryFixture.kt
+++ b/android/app/src/test/java/com/mulkkam/ui/fixture/HistoryFixture.kt
@@ -3,6 +3,7 @@ package com.mulkkam.ui.fixture
 import com.mulkkam.domain.model.intake.IntakeHistory
 import com.mulkkam.domain.model.intake.IntakeHistorySummaries
 import com.mulkkam.domain.model.intake.IntakeHistorySummary
+import com.mulkkam.domain.model.intake.IntakeType
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
@@ -34,16 +35,22 @@ val FULL_INTAKE_HISTORY =
                     id = 1,
                     dateTime = LocalTime.of(10, 0),
                     intakeAmount = 300,
+                    intakeType = IntakeType.WATER,
+                    cupEmojiUrl = "",
                 ),
                 IntakeHistory(
                     id = 1,
                     dateTime = LocalTime.of(11, 0),
                     intakeAmount = 400,
+                    intakeType = IntakeType.WATER,
+                    cupEmojiUrl = "",
                 ),
                 IntakeHistory(
                     id = 1,
                     dateTime = LocalTime.of(12, 0),
                     intakeAmount = 500,
+                    intakeType = IntakeType.WATER,
+                    cupEmojiUrl = "",
                 ),
             ),
     )


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #647 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 기록 화면에 액체 타입 이모지 띄움 ~

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 기록 화면에서 액체 타입에 따라 아이템에 이모지 표시
2. 액체 타입에 따라 음용 기록 텍스트 색깔 변경

이모지 뒤에 동그라미는 서버에서 주도록 수정될 것 같아서 배제했습니다 ~

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->

<img width="341" height="765" alt="스크린샷 2025-08-20 22 29 51" src="https://github.com/user-attachments/assets/db167232-3f25-4178-a964-be98c2fda6d6" />
