### PR TITLE
[BE][feat]: 로깅 처리 개선

### DIFF
--- a/backend/src/main/java/backend/mulkkam/common/filter/HttpLoggingFilter.java
+++ b/backend/src/main/java/backend/mulkkam/common/filter/HttpLoggingFilter.java
@@ -71,12 +71,6 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
         log.info("[REQUEST] {} {} token = {}", methodType, uri, auth);
     }
 
-    private String buildDecodedRequestUri(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        String query = decodeQuery(request.getQueryString());
-        return (query == null || query.isBlank()) ? path : path + "?" + query;
-    }
-
     private String decodeQuery(String rawQuery) {
         if (rawQuery == null) {
             return null;
@@ -116,6 +110,7 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             ContentCachingResponseWrapper responseWrapper
     ) {
         Long accountId = (Long) request.getAttribute("account_id");
+        String uri = buildDecodedRequestUri(request);
         String auth = response.getHeader("Authorization");
         HttpStatus status = HttpStatus.valueOf(response.getStatus());
         if (maskAuth) {
@@ -134,6 +129,12 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             body = responseWrapper.getContentType() + "NOT JSON";
         }
 
-        log.info("[RESPONSE] accountId = {}, ({}) token = {}, responseBody: {}", accountId, status, auth, body);
+        log.info("[RESPONSE] {} accountId = {}, ({}) token = {}, responseBody: {}", uri, accountId, status, auth, body);
+    }
+
+    private String buildDecodedRequestUri(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String query = decodeQuery(request.getQueryString());
+        return (query == null || query.isBlank()) ? path : path + "?" + query;
     }
 }

--- a/backend/src/main/java/backend/mulkkam/common/filter/HttpLoggingFilter.java
+++ b/backend/src/main/java/backend/mulkkam/common/filter/HttpLoggingFilter.java
@@ -129,7 +129,6 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             String body = objectMapper.readTree(responseWrapper.getContentAsByteArray())
                     .toPrettyString()
                     .replaceAll("\\R\\s*\\}$", "}");
-            log.info("ResponseBody: {}", body);
             if (body.isEmpty()) {
                 body = "NONE";
             }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <!-- ================== -->
     <!-- 파일: 컬러 없음, Asia/Seoul -->
     <property name="FILE_PATTERN"
-              value="[%d{yyyy-MM-dd'T'HH:mm:ss, Asia/Seoul}] %-5level %replace(%X{traceId}){'^(.+)$','[trace=\1]'} - %msg%n"/>
+              value="[%d{yyyy-MM-dd'T'HH:mm:ss, Asia/Seoul}] %-5level [%X{traceId}] - %msg%n"/>
 
     <!-- ================== -->
     <!-- DEV 환경 -->

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <!-- ================== -->
     <!-- 파일: 컬러 없음, Asia/Seoul -->
     <property name="FILE_PATTERN"
-              value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSSX, Asia/Seoul}:%-4relative] %-5level %green(%replace(%X{traceId}){'^(.+)$','[trace=\1]'}) - %msg%n"/>
+              value="[%d{yyyy-MM-dd'T'HH:mm:ss, Asia/Seoul}] %-5level %green(%replace(%X{traceId}){'^(.+)$','[trace=\1]'}) - %msg%n"/>
 
     <!-- ================== -->
     <!-- DEV 환경 -->

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <!-- ================== -->
     <!-- 파일: 컬러 없음, Asia/Seoul -->
     <property name="FILE_PATTERN"
-              value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSSX, Asia/Seoul}:%-4relative] [%thread] %-5level %green([trace=%X{traceId}]) - %msg%n"/>
+              value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSSX, Asia/Seoul}:%-4relative] %-5level %green([trace=%X{traceId}]) - %msg%n"/>
 
     <!-- ================== -->
     <!-- DEV 환경 -->

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <!-- ================== -->
     <!-- 파일: 컬러 없음, Asia/Seoul -->
     <property name="FILE_PATTERN"
-              value="[%d{yyyy-MM-dd'T'HH:mm:ss, Asia/Seoul}] %-5level %green(%replace(%X{traceId}){'^(.+)$','[trace=\1]'}) - %msg%n"/>
+              value="[%d{yyyy-MM-dd'T'HH:mm:ss, Asia/Seoul}] %-5level %replace(%X{traceId}){'^(.+)$','[trace=\1]'} - %msg%n"/>
 
     <!-- ================== -->
     <!-- DEV 환경 -->

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <!-- ================== -->
     <!-- 파일: 컬러 없음, Asia/Seoul -->
     <property name="FILE_PATTERN"
-              value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSSX, Asia/Seoul}:%-4relative] %-5level %green([trace=%X{traceId}]) - %msg%n"/>
+              value="[%d{yyyy-MM-dd'T'HH:mm:ss.SSSX, Asia/Seoul}:%-4relative] %-5level %green(%replace(%X{traceId}){'^(.+)$','[trace=\1]'}) - %msg%n"/>
 
     <!-- ================== -->
     <!-- DEV 환경 -->


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #648

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
로깅 관련해서 개선이 필요하다고 판단 된 것들을 한번에 정리해서 처리해봤어요!

아래와 같은 개선 요청 사안들이 있었습니다~
1. AWS 응답 로그 단일 라인화
2. traceId= 접두사 제거
3. 응답 로그에 endPoint 추가
4. 로깅에 traceId 앞뒤로 잘못된 숫자 뜨는 거 처리하기 -> 색상 코드 때문,,

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
아래 커밋에서 변경되었습니다!
1. [refactor: aws response 한줄 이벤트 처리](https://github.com/woowacourse-teams/2025-mul-kkam/pull/689/commits/de199957bbcb516fe5a2dc941eb0e6d5d947f183)
2. [chore: trace ID 출력 형식 변경](https://github.com/woowacourse-teams/2025-mul-kkam/pull/689/commits/6f8be8c1db0ff40e2aa80a1f3ce6edf26359d92d)
3. [refactor: aws response 한줄 이벤트 처리](https://github.com/woowacourse-teams/2025-mul-kkam/pull/689/commits/de199957bbcb516fe5a2dc941eb0e6d5d947f183)
4. [chore: logback 설정에 tracedId 색상 제거](https://github.com/woowacourse-teams/2025-mul-kkam/pull/689/commits/e861274439de1ebd1346c4f4c0c691c57db41e01)

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->

<img width="2710" height="862" alt="image" src="https://github.com/user-attachments/assets/3e3f0ef5-810e-4de8-ab78-de0a66015d1f" />

