### PR TITLE
[BE][chore]: flyway 구동 시 애플리케이션에 새로운 버전이 없더라도 구동하도록 설정 변경

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -22,6 +22,7 @@ spring:
     validate-on-migrate: true
     locations: classpath:db/migration
     clean-disabled: true
+    ignore-migration-patterns: *:future
 
 security:
   jwt:


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #695 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 애플리케이션에 없는 이후 버전이 적용되어도 정상적으로 구동하도록 변경합니다.

## 해당 설정이 필요한 이유
현재 롤백 시 스키마의 변경 시나리오는 다음과 같습니다.

1. v1 애플리케이션 배포 -> flyway 에 v1 에 해당하는 스크립트 모두 적용됨
2. v2 애플리케이션 배포 -> flyway 에 v2 에 해당하는 스크립트 모두 적용됨
3. v1 으로 롤백 -> v2 에 해당하는 스크립트가 이미 DB 에 적용됐는데, 애플리케이션에 없기에 오류 발생 가능 💥

따라서, `future 에 대해서 이미 적용되어 있어도 무시한다` 라는 의미의 설정을 추가했습니다.

cc. gemini 의 답변
```
Flyway가 현재 애플리케이션 버전에 없는, 더 높은 버전의 마이그레이션 스크립트가 이미 데이터베이스에 적용된 경우 이를 무시할지 여부를 결정합니다. 
이 옵션은 보통 여러 버전의 애플리케이션이 공존하거나, 롤링 업데이트(rolling update)를 할 때 유용합니다. 
예를 들어, v2.0 애플리케이션을 배포하기 전에 v2.1 마이그레이션이 이미 적용되었을 때, ignore-future-migrations를 true로 설정하면 v2.0이 정상적으로 시작될 수 있습니다.
```

해당 ignore-future-migrations 는 deprecated 되어 패턴 기반의 `ignore-migration-patterns: *:future` 를 사용했습니다.