### PR TITLE
[BE][refactor]: MemberResolver 관련 리팩터링

### DIFF
--- a/backend/src/main/java/backend/mulkkam/common/exception/errorCode/UnauthorizedErrorCode.java
+++ b/backend/src/main/java/backend/mulkkam/common/exception/errorCode/UnauthorizedErrorCode.java
@@ -7,6 +7,7 @@ public enum UnauthorizedErrorCode implements ErrorCode {
     UNAUTHORIZED,
     MISSING_AUTHORIZATION_HEADER,
     INVALID_AUTHORIZATION_HEADER,
+    ONBOARDING_HAS_NOT_FINISHED,
     ;
 
     @Override

--- a/backend/src/main/java/backend/mulkkam/common/resolver/MemberResolver.java
+++ b/backend/src/main/java/backend/mulkkam/common/resolver/MemberResolver.java
@@ -1,6 +1,7 @@
 package backend.mulkkam.common.resolver;
 
 import static backend.mulkkam.common.exception.errorCode.NotFoundErrorCode.NOT_FOUND_OAUTH_ACCOUNT;
+import static backend.mulkkam.common.exception.errorCode.UnauthorizedErrorCode.ONBOARDING_HAS_NOT_FINISHED;
 
 import backend.mulkkam.auth.domain.OauthAccount;
 import backend.mulkkam.auth.repository.OauthAccountRepository;
@@ -38,6 +39,10 @@ public class MemberResolver implements HandlerMethodArgumentResolver {
         Long accountId = (Long) request.getAttribute("account_id");
         OauthAccount account = oauthAccountRepository.findByIdWithMember(accountId)
                 .orElseThrow(() -> new CommonException(NOT_FOUND_OAUTH_ACCOUNT));
+
+        if (account.getMember() == null) {
+            throw new CommonException(ONBOARDING_HAS_NOT_FINISHED);
+        }
 
         return new MemberDetails(account.getMember().getId());
     }


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #697 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- MemberResolver 내부에서 OauthAccount 의 Member 가 null 인 경우 예외를 던지도록 수정

## ✅ 확인해야 하는 부분
기존에 태스크 분배 시 Resolver 내부에서 DB 접근하는 부분에 대한 우려가 있어, 구조 리팩터링을 하고자 했습니다.
그러나 새로운 구조에 대해 고려해본 결과, `현재 구조를 유지하는 것이 가장 낫다`는 판단을 하게 됐습니다.
이와 관련해서는 [의사 결정 문서](https://wealthy-clematis-4a5.notion.site/Resolver-2615bca0ac2280a38707e3749c79dc19?source=copy_link) 에 더 자세히 정리해두었습니다.

해당 부분 확인해보시고, `현 PR 에 의견 남겨주세요`.

## 🤔 고민하고 있는 부분
현재 diff 에 찍히지는 않았지만, OauthAccountResolver 에서는 현재 DB 접근을 하지 않고 있습니다. 즉, OatuhAccount 가 존재하지 않더라도 해당 Resolver 에서 넘어가게 됩니다.

반면, MemberResolver 에서는 OauthAccount 에 대해 존재하는지 확인한 뒤에, Member 의 id 를 반환합니다.

통일성이 없다는 우려가 들기도 했으나, 다음과 같은 이유로 우선은 뒀습니다.
- Member 는 결국 Oauthaccount 를 통해 접근해야 하니, `MemberResolver` 내부에서의 DB 접근 및 OauthAccount 의 유무 확인은 불가피
- OauthAccountResolver 에서는 OauthAccount 의 유무를 확인하지 않고 서비스로 넘기고 있고, MemberResolver 역시 Member 에 대한 유무는 확인하지 않고 서비스로 넘기고 있으니 통일성이 존재할 수도 있을 것 같다는 의견

이에 대해서도 의견 주세요~!

```java
@Override
  public OauthAccountDetails resolveArgument(
          MethodParameter parameter,
          ModelAndViewContainer mavContainer,
          NativeWebRequest webRequest,
          WebDataBinderFactory binderFactory
  ) {
      HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);

      Long accountId = (Long) request.getAttribute("account_id");

      return new OauthAccountDetails(accountId);
  }
```