### PR TITLE
[BE][feat]: 온보딩 endPoint 수정 - 칼리

### DIFF
--- a/backend/src/main/java/backend/mulkkam/member/controller/OnboardingController.java
+++ b/backend/src/main/java/backend/mulkkam/member/controller/OnboardingController.java
@@ -44,7 +44,7 @@ public class OnboardingController {
 
     @Operation(summary = "온보딩 상태 확인", description = "회원의 온보딩 완료 여부를 확인합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = OnboardingStatusResponse.class)))
-    @GetMapping("/check/onboarding")
+    @GetMapping("/check")
     public ResponseEntity<OnboardingStatusResponse> checkOnboardingStatus(
             @Parameter(hidden = true)
             OauthAccountDetails accountDetails

--- a/backend/src/test/java/backend/mulkkam/MulKkamApplicationTests.java
+++ b/backend/src/test/java/backend/mulkkam/MulKkamApplicationTests.java
@@ -9,5 +9,4 @@ class MulKkamApplicationTests {
     @Test
     void contextLoads() {
     }
-
 }

--- a/backend/src/test/java/backend/mulkkam/cup/controller/CupControllerTest.java
+++ b/backend/src/test/java/backend/mulkkam/cup/controller/CupControllerTest.java
@@ -340,9 +340,7 @@ class CupControllerTest extends ControllerTest {
 
             FailureBody actual = objectMapper.readValue(json, FailureBody.class);
 
-            assertSoftly(softly -> {
-                softly.assertThat(actual.getCode()).isEqualTo(NOT_PERMITTED_FOR_CUP.name());
-            });
+            assertThat(actual.getCode()).isEqualTo(NOT_PERMITTED_FOR_CUP.name());
         }
 
         @DisplayName("요청애 랭크가 중복적으로 들어왔을 때 예외를 발생시킨다")
@@ -529,9 +527,7 @@ class CupControllerTest extends ControllerTest {
 
             FailureBody actual = objectMapper.readValue(json, FailureBody.class);
 
-            assertSoftly(softly -> {
-                softly.assertThat(actual.getCode()).isEqualTo(NOT_FOUND_CUP.name());
-            });
+            assertThat(actual.getCode()).isEqualTo(NOT_FOUND_CUP.name());
         }
     }
 

--- a/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/controller/MemberControllerTest.java
@@ -47,11 +47,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-@AutoConfigureMockMvc
 class MemberControllerTest extends ControllerTest {
 
     @Autowired


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #727 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 온보딩 상태 조회 API 엔드포인트를 /onboarding/check로 정리하여 경로를 일관되게 개선했습니다. 기존 호출을 사용하는 경우 새 경로로 업데이트가 필요할 수 있습니다.

* **Tests**
  * 테스트 코드의 불필요한 어서션과 설정을 정리하여 가독성과 유지보수성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->