### PR TITLE
[BE][fix]: 알림 이벤트 테스트 실패 수정

### DIFF
--- a/backend/src/test/java/backend/mulkkam/notification/service/NotificationServiceUnitTest.java
+++ b/backend/src/test/java/backend/mulkkam/notification/service/NotificationServiceUnitTest.java
@@ -13,7 +13,6 @@ import backend.mulkkam.averageTemperature.dto.CreateTokenNotificationRequest;
 import backend.mulkkam.common.dto.MemberDetails;
 import backend.mulkkam.common.exception.CommonException;
 import backend.mulkkam.common.infrastructure.fcm.domain.Action;
-import backend.mulkkam.common.infrastructure.fcm.dto.SendTokenEvent;
 import backend.mulkkam.common.infrastructure.fcm.dto.request.SendMessageByFcmTokenRequest;
 import backend.mulkkam.device.domain.Device;
 import backend.mulkkam.device.repository.DeviceRepository;
@@ -25,8 +24,8 @@ import backend.mulkkam.notification.dto.GetUnreadNotificationsCountResponse;
 import backend.mulkkam.notification.dto.NotificationResponse;
 import backend.mulkkam.notification.dto.ReadNotificationsResponse;
 import backend.mulkkam.notification.repository.NotificationRepository;
-import backend.mulkkam.support.fixture.member.MemberFixtureBuilder;
 import backend.mulkkam.support.fixture.NotificationFixtureBuilder;
+import backend.mulkkam.support.fixture.member.MemberFixtureBuilder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -255,13 +254,11 @@ class NotificationServiceUnitTest {
             verify(deviceRepository).findAllByMember(member);
 
             verify(applicationEventPublisher).publishEvent(
-                    argThat((SendTokenEvent evt) -> {
-                        SendMessageByFcmTokenRequest r = evt.sendMessageByFcmTokenRequest();
-                        return r.title().equals("title")
-                                && r.body().equals("body")
-                                && r.token().equals("token-1")
-                                && r.action() == Action.GO_HOME;
-                    })
+                    argThat((SendMessageByFcmTokenRequest evt) ->
+                            evt.title().equals("title")
+                                    && evt.body().equals("body")
+                                    && evt.token().equals("token-1")
+                                    && evt.action() == Action.GO_HOME)
             );
         }
     }


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #{Issue Number}

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 알림 서비스 단위 테스트를 이벤트 타입 변경에 맞춰 수정했습니다. 기존 래퍼 이벤트 대신 FCM 토큰 요청 객체의 필드(title, body, token, action)를 직접 검증하도록 업데이트했습니다.
  * 관련 임포트를 정리하고 불필요한 의존성을 제거했습니다.
  * 프로덕션 코드 변경은 없으며, 사용자에게 노출되는 기능과 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->