### PR TITLE
[BE][feat]: 음용량 추가 요청의 응답에 음용 타입 추가

### DIFF
--- a/backend/src/main/java/backend/mulkkam/intake/dto/CreateIntakeHistoryDetailResponse.java
+++ b/backend/src/main/java/backend/mulkkam/intake/dto/CreateIntakeHistoryDetailResponse.java
@@ -1,5 +1,6 @@
 package backend.mulkkam.intake.dto;
 
+import backend.mulkkam.cup.domain.IntakeType;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -10,6 +11,8 @@ public record CreateIntakeHistoryDetailResponse(
         @Parameter(description = "캐릭터 상태 설명 코멘트", example = "하뭉이는 신나요")
         String comment,
         @Parameter(description = "음용량", example = "300")
-        int intakeAmount
+        int intakeAmount,
+        @Parameter(description = "음용 타입", example = "COFFEE")
+        IntakeType intakeType
 ) {
 }

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeHistoryService.java
@@ -32,15 +32,14 @@ import backend.mulkkam.intake.repository.TargetAmountSnapshotRepository;
 import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.domain.vo.TargetAmount;
 import backend.mulkkam.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -80,7 +79,8 @@ public class IntakeHistoryService {
                 intakeDate,
                 member,
                 intakeHistory,
-                intakeHistoryDetail.getIntakeAmount().value()
+                intakeHistoryDetail.getIntakeAmount().value(),
+                cup.getIntakeType()
         );
     }
 
@@ -110,7 +110,8 @@ public class IntakeHistoryService {
                 intakeDate,
                 member,
                 intakeHistory,
-                intakeHistoryDetail.getIntakeAmount().value()
+                intakeHistoryDetail.getIntakeAmount().value(),
+                intakeType
         );
     }
 
@@ -176,7 +177,8 @@ public class IntakeHistoryService {
             LocalDate intakeDate,
             Member member,
             IntakeHistory intakeHistory,
-            int intakeAmount
+            int intakeAmount,
+            IntakeType intakeType
     ) {
         List<IntakeHistoryDetail> intakeHistoryDetails = findIntakeHistoriesOfDate(intakeDate, member);
 
@@ -184,7 +186,8 @@ public class IntakeHistoryService {
         AchievementRate achievementRate = new AchievementRate(totalIntakeAmount, intakeHistory.getTargetAmount());
         String commentByAchievementRate = CommentOfAchievementRate.findCommentByAchievementRate(achievementRate);
 
-        return new CreateIntakeHistoryDetailResponse(achievementRate.value(), commentByAchievementRate, intakeAmount);
+        return new CreateIntakeHistoryDetailResponse(achievementRate.value(), commentByAchievementRate, intakeAmount,
+                intakeType);
     }
 
     private IntakeHistory getIntakeHistory(


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #811 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 음용 기록 생성 응답에 ‘음용 타입’ 정보가 추가되어(예: COFFEE) 기록 상세에서 음용 유형을 확인할 수 있습니다.
- 문서화
  - 스웨거 문서에 ‘음용 타입’ 설명과 예시가 추가되어 API 응답 이해가 향상되었습니다.
- 참고
  - 클라이언트는 신규 필드(음용 타입)를 처리하도록 업데이트가 필요할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->