### PR TITLE
[AN][fix]: 1x4 위젯에서 원형 그래프가 잘리는 문제 해결

### DIFF
--- a/android/app/src/main/res/layout/layout_intake_widget.xml
+++ b/android/app/src/main/res/layout/layout_intake_widget.xml
@@ -15,18 +15,20 @@
         android:paddingHorizontal="18dp">
 
         <FrameLayout
-            android:layout_width="78dp"
-            android:layout_height="78dp">
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
 
             <ImageView
                 android:id="@+id/iv_donut_chart"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
 
             <ImageView
                 android:id="@+id/iv_character"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_width="70dp"
+                android:layout_height="70dp"
+                android:layout_gravity="center"
                 android:layout_margin="4dp"
                 android:src="@drawable/img_widget_character" />
         </FrameLayout>


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #840

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 그래프 이미지 `wrap_content` 로 바꿈

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 이미지뷰 사이즈 변경

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->
- 사실 테스트는 못했는데 이래도 안되면 억까데스

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Rebuilt Notifications with Jetpack Compose: modern top app bar, empty state screen, loading shimmer, swipe-to-delete, and apply-suggestion actions with toasts and back navigation.
  - Added composable components for notification items and content with relative time.

- Refactor
  - Migrated Notifications from RecyclerView to Compose; removed legacy adapter and touch helper.
  - Standardized back icons across multiple screens.

- Bug Fixes
  - Improved image placeholders for cup/emoji images.
  - Updated history “no record” character image.

- Documentation
  - Coffee Encyclopedia updated with reorganized content and a source link.

- Chores
  - Added Lifecycle ViewModel Compose dependency.
  - Renamed and added notification-related strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->