### PR TITLE
[BE][refactor]: oauth_account 테이블 불필요한 칼럼 삭제

### DIFF
--- a/backend/src/main/java/backend/mulkkam/intake/domain/TargetAmountSnapshot.java
+++ b/backend/src/main/java/backend/mulkkam/intake/domain/TargetAmountSnapshot.java
@@ -13,11 +13,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -34,7 +35,7 @@ public class TargetAmountSnapshot extends BaseEntity {
     @JoinColumn(nullable = false)
     private Member member;
 
-    @Column(nullable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDate updatedAt;
 
     @Embedded
@@ -51,7 +52,17 @@ public class TargetAmountSnapshot extends BaseEntity {
         this.targetAmount = targetAmount;
     }
 
+    public TargetAmountSnapshot(
+            Member member,
+            TargetAmount targetAmount
+    ) {
+        this.member = member;
+        this.updatedAt = LocalDate.now();
+        this.targetAmount = targetAmount;
+    }
+
     public void updateTargetAmount(TargetAmount targetAmount) {
         this.targetAmount = targetAmount;
+        this.updatedAt = LocalDate.now();
     }
 }

--- a/backend/src/main/java/backend/mulkkam/intake/service/IntakeAmountService.java
+++ b/backend/src/main/java/backend/mulkkam/intake/service/IntakeAmountService.java
@@ -19,11 +19,12 @@ import backend.mulkkam.member.domain.Member;
 import backend.mulkkam.member.domain.vo.PhysicalAttributes;
 import backend.mulkkam.member.domain.vo.TargetAmount;
 import backend.mulkkam.member.repository.MemberRepository;
-import java.time.LocalDate;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -99,7 +100,7 @@ public class IntakeAmountService {
             foundTargetAmountSnapshot.get().updateTargetAmount(member.getTargetAmount());
             return;
         }
-        targetAmountSnapshotRepository.save(new TargetAmountSnapshot(member, today, member.getTargetAmount()));
+        targetAmountSnapshotRepository.save(new TargetAmountSnapshot(member, member.getTargetAmount()));
     }
 
     private int findStreak(Member member, LocalDate todayDate) {

--- a/backend/src/main/java/backend/mulkkam/member/service/OnboardingService.java
+++ b/backend/src/main/java/backend/mulkkam/member/service/OnboardingService.java
@@ -17,11 +17,11 @@ import backend.mulkkam.member.repository.MemberRepository;
 import backend.mulkkam.notification.domain.Notification;
 import backend.mulkkam.notification.domain.NotificationType;
 import backend.mulkkam.notification.repository.NotificationRepository;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
@@ -47,7 +47,6 @@ public class OnboardingService {
 
         TargetAmountSnapshot targetAmountSnapshot = new TargetAmountSnapshot(
                 member,
-                LocalDate.now(),
                 new TargetAmount(createMemberRequest.targetIntakeAmount())
         );
         targetAmountSnapshotRepository.save(targetAmountSnapshot);

--- a/backend/src/main/resources/db/migration/common/V20250923_200801__drop_deleted_at_oauth_account.sql
+++ b/backend/src/main/resources/db/migration/common/V20250923_200801__drop_deleted_at_oauth_account.sql
@@ -1,0 +1,4 @@
+-- ALLOW_DROP
+-- reason: oauth_account 는 soft delete 대상 아님 (843)
+ALTER TABLE oauth_account
+    DROP COLUMN deleted_at;

--- a/backend/src/main/resources/db/migration/common/V20250924_143001__modify_updated_at_target_amount_snapshot.sql
+++ b/backend/src/main/resources/db/migration/common/V20250924_143001__modify_updated_at_target_amount_snapshot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE target_amount_snapshot
+    MODIFY COLUMN updated_at DATE NOT NULL DEFAULT (CURRENT_DATE);

--- a/backend/src/main/resources/db/migration/common/V20250924_164501__drop_created_at_and_deleted_at_suggestion_notification.sql
+++ b/backend/src/main/resources/db/migration/common/V20250924_164501__drop_created_at_and_deleted_at_suggestion_notification.sql
@@ -1,3 +1,6 @@
+-- ALLOW_DROP
+-- reason: suggestion_notification 은 soft delete 대상 아님. notification 을 통해 soft delete 이뤄짐 (843)
+
 ALTER TABLE suggestion_notification
     DROP COLUMN created_at;
 

--- a/backend/src/main/resources/db/migration/common/V20250924_164501__drop_created_at_and_deleted_at_suggestion_notification.sql
+++ b/backend/src/main/resources/db/migration/common/V20250924_164501__drop_created_at_and_deleted_at_suggestion_notification.sql
@@ -1,0 +1,5 @@
+ALTER TABLE suggestion_notification
+    DROP COLUMN created_at;
+
+ALTER TABLE suggestion_notification
+    DROP COLUMN deleted_at;


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
close #843

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 데이터베이스 스키마 정리: OAuth 계정의 불필요한 삭제 표시 컬럼 및 알림 관련 불필요한 시간 컬럼(created_at, deleted_at) 제거.
  * 데이터 무결성 강화: 타깃 금액 스냅샷의 updated_at을 비어있을 수 없게 변경하고 생성 시 기본값을 현재 날짜로 설정.
  * 내부 동작 변경: 스냅샷 생성 시 생성일을 내부에서 자동 설정하도록 조정.

* **서비스 영향**
  * 기능 변화 없음 — 무중단 마이그레이션, 사용자 조치 불필요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->