### PR TITLE
[BE][feat]: 컵 디폴트 이미지 url 변경

### DIFF
--- a/backend/src/main/java/backend/mulkkam/cup/domain/DefaultCup.java
+++ b/backend/src/main/java/backend/mulkkam/cup/domain/DefaultCup.java
@@ -46,4 +46,8 @@ public enum DefaultCup {
                 .filter(v -> v.intakeType == type)
                 .findFirst();
     }
+
+    public static EmojiCode getHighestPriorityEmojiCode() {
+        return EmojiCode.of(IntakeType.WATER, EmojiType.DEFAULT);
+    }
 }

--- a/backend/src/main/java/backend/mulkkam/cup/repository/CupEmojiRepository.java
+++ b/backend/src/main/java/backend/mulkkam/cup/repository/CupEmojiRepository.java
@@ -6,8 +6,22 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CupEmojiRepository extends JpaRepository<CupEmoji, Long>  {
 
     List<CupEmoji> findAllByCodeIn(Collection<EmojiCode> defaultEmojiCodes);
+
+    @Query("""
+        SELECT c
+        FROM CupEmoji c
+        WHERE c.deletedAt IS NULL
+        ORDER BY
+            CASE
+                WHEN :highestPriorityEmojiCode IS NOT NULL AND c.code = :highestPriorityEmojiCode THEN 0
+                ELSE 1
+            END,
+            c.code ASC NULLS LAST
+    """)
+    List<CupEmoji> findAllOrderByCode(EmojiCode highestPriorityEmojiCode);
 }

--- a/backend/src/main/java/backend/mulkkam/cup/service/CupEmojiService.java
+++ b/backend/src/main/java/backend/mulkkam/cup/service/CupEmojiService.java
@@ -1,6 +1,7 @@
 package backend.mulkkam.cup.service;
 
 import backend.mulkkam.cup.domain.CupEmoji;
+import backend.mulkkam.cup.domain.DefaultCup;
 import backend.mulkkam.cup.dto.CupEmojiResponse;
 import backend.mulkkam.cup.dto.CupEmojisResponse;
 import backend.mulkkam.cup.repository.CupEmojiRepository;
@@ -16,7 +17,7 @@ public class CupEmojiService {
     private final CupEmojiRepository cupEmojiRepository;
 
     public CupEmojisResponse readAll() {
-        List<CupEmoji> cupEmojis = cupEmojiRepository.findAll();
+        List<CupEmoji> cupEmojis = cupEmojiRepository.findAllOrderByCode(DefaultCup.getHighestPriorityEmojiCode());
         return new CupEmojisResponse(toCupEmojiResponse(cupEmojis));
     }
 

--- a/backend/src/main/resources/db/migration/common/R__202509241258_modify_cup_emoji.sql
+++ b/backend/src/main/resources/db/migration/common/R__202509241258_modify_cup_emoji.sql
@@ -1,0 +1,28 @@
+-- 기존에 있던 water와 coffee의 순서 변경
+
+
+-- 배경이 원이었던 이모지들을 네모로 바꾸는 스크립트
+
+-- water
+UPDATE cup_emoji
+SET url  = 'https://github.com/user-attachments/assets/e3a29279-8c7c-403a-b19f-3035005b00a2'
+WHERE url = 'https://github.com/user-attachments/assets/e096b351-c8c1-494e-abad-5c9881af7ef5'
+  AND deleted_at IS NULL;
+
+-- coffee
+UPDATE cup_emoji
+SET url  = 'https://github.com/user-attachments/assets/9a070802-5309-4508-acdb-faec9375e7c7'
+WHERE url = 'https://github.com/user-attachments/assets/c045e7ff-96b4-4c14-83bc-706112c1e871'
+  AND deleted_at IS NULL;
+
+-- 텀블러 이모지 url 이 존재하지 않으면 삽입
+INSERT INTO cup_emoji (url, code, created_at, deleted_at)
+SELECT
+    'https://github.com/user-attachments/assets/3e948e3b-15db-444b-a7de-df6ef48c7c7e',
+    NULL,
+    CURRENT_TIMESTAMP,
+    NULL
+    WHERE NOT EXISTS (
+    SELECT 1 FROM cup_emoji
+    WHERE url = 'https://github.com/user-attachments/assets/3e948e3b-15db-444b-a7de-df6ef48c7c7e'
+);


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #846 

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 알림 미읽음 개수 조회 엔드포인트 추가 (/notifications/unread-count).
  - 매일 08:00 날씨 기반 수분 섭취 제안 알림, 14:00/19:00 리마인드 알림 발송.
  - 활동 기반 제안 알림 생성 엔드포인트 추가.

- 변경
  - 섭취량 API 용어 “추천(Recommended)” → “제안(Suggestion)”, 응답 필드 단순화(int).
  - 알림 조회 요청 DTO 명칭 정리(호출 방식 동일).

- 개선
  - 도시(서울) 기준 날씨 처리로 정확도 향상.
  - 이모지 목록 정렬 개선(기본 물 이모지 우선).

- UI/에셋
  - 물/커피 이모지 이미지 교체, 텀블러 이모지 추가.

- 제거/폐지
  - 레거시 FCM 직접 발송 엔드포인트 폐지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->