### PR TITLE
[AN][fix]: reissue 비동기 이슈 해결

### DIFF
--- a/android/app/src/main/java/com/mulkkam/data/remote/interceptor/TokenRefresher.kt
+++ b/android/app/src/main/java/com/mulkkam/data/remote/interceptor/TokenRefresher.kt
@@ -1,7 +1,6 @@
 package com.mulkkam.data.remote.interceptor
 
 import com.mulkkam.data.remote.model.request.auth.AuthReissueRequest
-import com.mulkkam.di.LoggingInjection.mulKkamLogger
 import com.mulkkam.di.PreferenceInjection.devicesPreference
 import com.mulkkam.di.PreferenceInjection.tokenPreference
 import com.mulkkam.di.ServiceInjection
@@ -29,7 +28,6 @@ object TokenRefresher {
                         runCatching {
                             ServiceInjection.authService.postAuthTokenReissue(AuthReissueRequest(refreshToken, deviceUuid))
                         }.getOrNull() ?: return@async null
-                    mulKkamLogger.debug(message = "123123: ${result.toMulKkamResult().getOrError()}")
 
                     return@async runCatching {
                         val info = result.toMulKkamResult().getOrError()

--- a/android/app/src/main/java/com/mulkkam/data/remote/interceptor/TokenRefresher.kt
+++ b/android/app/src/main/java/com/mulkkam/data/remote/interceptor/TokenRefresher.kt
@@ -1,0 +1,56 @@
+package com.mulkkam.data.remote.interceptor
+
+import com.mulkkam.data.remote.model.request.auth.AuthReissueRequest
+import com.mulkkam.di.LoggingInjection.mulKkamLogger
+import com.mulkkam.di.PreferenceInjection.devicesPreference
+import com.mulkkam.di.PreferenceInjection.tokenPreference
+import com.mulkkam.di.ServiceInjection
+import com.mulkkam.domain.model.result.toMulKkamResult
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicReference
+
+object TokenRefresher {
+    private val currentJob = AtomicReference<Deferred<String?>?>(null)
+
+    fun refresh(): String? =
+        runBlocking {
+            currentJob.get()?.let { return@runBlocking it.await() }
+
+            val newJob =
+                async(Dispatchers.IO, start = CoroutineStart.LAZY) {
+                    val refreshToken = tokenPreference.refreshToken ?: return@async null
+                    val deviceUuid = devicesPreference.deviceUuid ?: return@async null
+
+                    val result =
+                        runCatching {
+                            ServiceInjection.authService.postAuthTokenReissue(AuthReissueRequest(refreshToken, deviceUuid))
+                        }.getOrNull() ?: return@async null
+                    mulKkamLogger.debug(message = "123123: ${result.toMulKkamResult().getOrError()}")
+
+                    return@async runCatching {
+                        val info = result.toMulKkamResult().getOrError()
+                        tokenPreference.saveAccessToken(info.accessToken)
+                        tokenPreference.saveRefreshToken(info.refreshToken)
+                        info.accessToken
+                    }.getOrElse {
+                        null
+                    }
+                }
+
+            if (currentJob.compareAndSet(null, newJob)) {
+                try {
+                    newJob.start()
+                    newJob.await()
+                } finally {
+                    currentJob.set(null)
+                }
+            } else {
+                newJob.cancel()
+                currentJob.get()!!.await()
+            }
+        }
+}

--- a/android/app/src/main/java/com/mulkkam/data/remote/interceptor/TokenRefresher.kt
+++ b/android/app/src/main/java/com/mulkkam/data/remote/interceptor/TokenRefresher.kt
@@ -50,7 +50,7 @@ object TokenRefresher {
                 }
             } else {
                 newJob.cancel()
-                currentJob.get()!!.await()
+                currentJob.get()?.await()
             }
         }
 }


### PR DESCRIPTION
🔗 관련 이슈
- close #877

📝 작업 내용
- AuthorizationInterceptor 내 동시성 문제(동시에 여러 요청이 401 발생 시 중복 토큰 재발급 요청) 해결을 위해 단일 비행(single-flight) 토큰 재발급 게이트 구현
- AtomicReference<Deferred<String?>>를 이용하여 토큰 재발급 요청을 최초 1회만 수행하고, 다른 요청은 그 결과를 기다리도록 개선
- toMulKkamResult().getOrError() 기반으로 성공/실패를 판정하도록 수정

주요 변경사항
1. TokenRefresher 객체 추가
    - AtomicReference<Deferred<String?>?>를 사용하여 재발급 Job을 전역적으로 관리
    - compareAndSet(null, newJob)을 통해 첫 번째 호출만 실제 재발급 실행, 나머지는 대기
2. 기존 isSuccess flag 검증 제거
    - 대신 toMulKkamResult().getOrError()에서 예외 발생 여부로 성공/실패 판정
3. 토큰 재발급 성공 시
    - 새 accessToken 및 refreshToken을 tokenPreference에 저장
    - 반환된 accessToken을 그대로 요청 헤더에 주입해 재시도 가능하도록 설계
4. 재발급 실패 시
    - null 반환 → 원래 응답 그대로 반환하여 무한 재시도 방지

📸 스크린샷 (Optional)
<img width="1179" height="280" alt="image" src="https://github.com/user-attachments/assets/486726ae-5e66-409b-85e7-af61653273dc" />

단일 요청 확인 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Redesigned Home screen with Compose, animated drink button/menu, progress overview, character, and confetti.
  - New Notification screen with unread counter, swipe-to-delete, apply-suggestion action, loading shimmer, and empty state.
  - Tapping a notification now opens the Notification screen.

- Improvements
  - Image loading now shows placeholders (including cups) and supports more shapes.
  - Updated coffee encyclopedia layout with a source section and refreshed back icons.
  - Refined history character image and intake widget sizing.
  - More reliable notification handling with distinct IDs.

- Documentation
  - README expanded with detailed setup, architecture, usage, and team info.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->