### PR TITLE
v2.1.1

### DIFF
--- a/backend/src/main/java/backend/mulkkam/friend/repository/FriendRepository.java
+++ b/backend/src/main/java/backend/mulkkam/friend/repository/FriendRepository.java
@@ -2,8 +2,7 @@ package backend.mulkkam.friend.repository;
 
 import backend.mulkkam.friend.domain.Friend;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,4 +26,12 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
                         OR f.addresseeId = :memberId AND f.requesterId = :friendId
             """)
     Optional<Friend> findByFriendIdAndMemberId(@Param("friendId") Long friendId, @Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("""
+        DELETE
+        FROM Friend f
+        WHERE f.addresseeId = :memberId OR f.requesterId = :memberId
+    """)
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/backend/mulkkam/friend/repository/FriendRequestRepository.java
+++ b/backend/src/main/java/backend/mulkkam/friend/repository/FriendRequestRepository.java
@@ -2,6 +2,17 @@ package backend.mulkkam.friend.repository;
 
 import backend.mulkkam.friend.domain.FriendRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+
+    @Modifying
+    @Query("""
+        DELETE
+        FROM FriendRequest fr
+        WHERE fr.requesterId = :memberId OR fr.addresseeId = :memberId
+    """)
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
+++ b/backend/src/main/java/backend/mulkkam/member/service/MemberService.java
@@ -11,6 +11,8 @@ import backend.mulkkam.common.dto.MemberDetails;
 import backend.mulkkam.common.exception.CommonException;
 import backend.mulkkam.cup.repository.CupRepository;
 import backend.mulkkam.device.repository.DeviceRepository;
+import backend.mulkkam.friend.repository.FriendRepository;
+import backend.mulkkam.friend.repository.FriendRequestRepository;
 import backend.mulkkam.intake.domain.IntakeHistory;
 import backend.mulkkam.intake.domain.vo.AchievementRate;
 import backend.mulkkam.intake.repository.TargetAmountSnapshotRepository;
@@ -29,6 +31,7 @@ import backend.mulkkam.member.repository.MemberRepository;
 import backend.mulkkam.notification.domain.Notification;
 import backend.mulkkam.notification.domain.NotificationType;
 import backend.mulkkam.notification.repository.NotificationRepository;
+import backend.mulkkam.notification.repository.ReminderScheduleRepository;
 import backend.mulkkam.notification.repository.SuggestionNotificationRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -49,6 +52,9 @@ public class MemberService {
     private final DeviceRepository deviceRepository;
     private final NotificationRepository notificationRepository;
     private final SuggestionNotificationRepository suggestionNotificationRepository;
+    private final ReminderScheduleRepository reminderScheduleRepository;
+    private final FriendRepository friendRepository;
+    private final FriendRequestRepository friendRequestRepository;
 
     private final IntakeHistoryCrudService intakeHistoryCrudService;
 
@@ -162,6 +168,10 @@ public class MemberService {
         List<Long> notificationIds = findSuggestionNotificationIdsByMember(member);
         suggestionNotificationRepository.deleteByIdIn(notificationIds);
         notificationRepository.deleteByMember(member);
+
+        reminderScheduleRepository.deleteAllByMemberId(member.getId());
+        friendRepository.deleteAllByMemberId(member.getId());
+        friendRequestRepository.deleteAllByMemberId(member.getId());
 
         memberRepository.delete(member);
     }

--- a/backend/src/main/java/backend/mulkkam/notification/repository/ReminderScheduleRepository.java
+++ b/backend/src/main/java/backend/mulkkam/notification/repository/ReminderScheduleRepository.java
@@ -35,4 +35,6 @@ public interface ReminderScheduleRepository extends JpaRepository<ReminderSchedu
                   AND (:lastId IS NULL OR r.id > :lastId)
             """)
     List<Long> findAllActiveMemberIdsByHourAndMinute(@Param("schedule") LocalTime schedule, @Param("lastId") Long lastId, Pageable pageable);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/backend/src/test/java/backend/mulkkam/member/service/MemberServiceIntegrationTest.java
+++ b/backend/src/test/java/backend/mulkkam/member/service/MemberServiceIntegrationTest.java
@@ -22,6 +22,10 @@ import backend.mulkkam.cup.repository.CupEmojiRepository;
 import backend.mulkkam.cup.repository.CupRepository;
 import backend.mulkkam.device.domain.Device;
 import backend.mulkkam.device.repository.DeviceRepository;
+import backend.mulkkam.friend.domain.Friend;
+import backend.mulkkam.friend.domain.FriendRequest;
+import backend.mulkkam.friend.repository.FriendRepository;
+import backend.mulkkam.friend.repository.FriendRequestRepository;
 import backend.mulkkam.intake.domain.IntakeHistory;
 import backend.mulkkam.intake.domain.IntakeHistoryDetail;
 import backend.mulkkam.intake.domain.vo.IntakeAmount;
@@ -39,7 +43,9 @@ import backend.mulkkam.member.dto.response.ProgressInfoResponse;
 import backend.mulkkam.member.repository.MemberRepository;
 import backend.mulkkam.notification.domain.Notification;
 import backend.mulkkam.notification.domain.NotificationType;
+import backend.mulkkam.notification.domain.ReminderSchedule;
 import backend.mulkkam.notification.repository.NotificationRepository;
+import backend.mulkkam.notification.repository.ReminderScheduleRepository;
 import backend.mulkkam.support.fixture.AccountRefreshTokenFixtureBuilder;
 import backend.mulkkam.support.fixture.IntakeHistoryDetailFixtureBuilder;
 import backend.mulkkam.support.fixture.IntakeHistoryFixtureBuilder;
@@ -54,6 +60,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 class MemberServiceIntegrationTest extends ServiceIntegrationTest {
 
@@ -91,6 +99,15 @@ class MemberServiceIntegrationTest extends ServiceIntegrationTest {
 
     @Autowired
     private CupEmojiRepository cupEmojiRepository;
+
+    @Autowired
+    private ReminderScheduleRepository reminderScheduleRepository;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @Autowired
+    private FriendRequestRepository friendRequestRepository;
 
     private final CupEmoji cupEmoji = new CupEmoji("http://example.com");
 
@@ -427,6 +444,10 @@ class MemberServiceIntegrationTest extends ServiceIntegrationTest {
             Member member = MemberFixtureBuilder.builder()
                     .build();
             memberRepository.save(member);
+            Member friendMember = MemberFixtureBuilder.builder()
+                    .memberNickname(new MemberNickname("친구"))
+                    .build();
+            memberRepository.save(friendMember);
 
             OauthAccount oauthAccount = OauthAccountFixtureBuilder
                     .withMember(member)
@@ -458,6 +479,16 @@ class MemberServiceIntegrationTest extends ServiceIntegrationTest {
             Notification notification = new Notification(NotificationType.NOTICE, "title", LocalDateTime.now(), member);
             notificationRepository.save(notification);
 
+            ReminderSchedule schedule1 = new ReminderSchedule(member, LocalTime.of(10, 0));
+            ReminderSchedule schedule2 = new ReminderSchedule(member, LocalTime.of(12, 0));
+            reminderScheduleRepository.saveAll(List.of(schedule1, schedule2));
+
+            Friend friend = new Friend(member.getId(), friendMember.getId());
+            friendRepository.save(friend);
+
+            FriendRequest friendRequest = new FriendRequest(member.getId(), friendMember.getId());
+            friendRequestRepository.save(friendRequest);
+
             // when
             memberService.delete(new MemberDetails(member));
 
@@ -470,6 +501,10 @@ class MemberServiceIntegrationTest extends ServiceIntegrationTest {
                 softly.assertThat(intakeHistoryDetailRepository.findById(intakeHistoryDetail.getId())).isEmpty();
                 softly.assertThat(deviceRepository.findById(device.getId())).isEmpty();
                 softly.assertThat(notificationRepository.findById(notification.getId())).isEmpty();
+                softly.assertThat(reminderScheduleRepository.findById(schedule1.getId())).isEmpty();
+                softly.assertThat(reminderScheduleRepository.findById(schedule2.getId())).isEmpty();
+                softly.assertThat(friendRepository.findById(friend.getId())).isEmpty();
+                softly.assertThat(friendRequestRepository.findById(friendRequest.getId())).isEmpty();
             });
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 개선
  * 회원 탈퇴 시 친구, 친구 요청, 리마인더 일정 등 연관 데이터가 함께 일괄 삭제되어 잔존 데이터 없이 깔끔한 계정 삭제 경험을 제공합니다.
* 테스트
  * 회원 탈퇴 통합 테스트를 확장해 연관 데이터(친구, 친구 요청, 리마인더 일정) 삭제가 정상 동작함을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->