### PR TITLE
v3.0.0 (재재업)

### DIFF
--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -35,7 +35,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
-		<string>healthkit</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- PR 제목은 이슈 제목과 동일하게 작성해주세요 -->

## 🔗 관련 이슈
<!-- 이슈 번호를 입력하세요 -->
- close #{Issue Number}

## 📝 작업 내용
<!-- 무엇을 개발했는지 간단히 설명해주세요 -->
- 

### 주요 변경사항
<!-- 어떤 사항들이 변경되었는지 설명해주세요 -->
1. 
2. 
3. 

## 📸 스크린샷 (Optional)
<!-- 구현 사항이 포함된 스크린샷을 첨부해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 🔗 관련 이슈
- close #1204

## 📝 작업 내용
Apple App Store 심사 지침에 위반되는 HealthKit 백그라운드 모드 설정을 제거합니다.

앱에서 HealthKit을 사용하여 사용자의 운동량(칼로리) 데이터를 읽어 운동 감지 기능을 제공하고 있습니다. 그러나 이 기능은 포그라운드에서만 필요하며, 백그라운드에서 HealthKit 데이터를 접근할 필요가 없습니다. 

Apple의 지침에 따르면 Info.plist의 UIBackgroundModes에 선언된 백그라운드 모드는 해당 기능이 실제로 백그라운드에서 작동해야 할 때만 선언해야 합니다. 불필요한 백그라운드 모드 선언은 거부 사유가 될 수 있으므로, 실제 용도에 맞게 수정합니다.

### 주요 변경사항
1. **Info.plist UIBackgroundModes 정정**
   - `healthkit` 백그라운드 모드 제거
   - `remote-notification` 모드만 유지 (푸시 알림용)
   - HealthKit 기능 자체는 유지 (포그라운드 사용)

2. **변경의 영향**
   - 앱의 HealthKit 데이터 읽기 기능에는 영향 없음 (포그라운드 작동)
   - App Store 심사 가이드라인 준수로 거부 가능성 제거
   - 불필요한 백그라운드 권한 요청 제거로 사용자 신뢰도 향상

## 📊 변경 효과 요약
정량 지표는 이번 PR에서 측정하지 않음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->